### PR TITLE
Language rename.

### DIFF
--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/parser/YangParser.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/parser/YangParser.java
@@ -1,6 +1,14 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.parser;
 
+import com.intellij.lang.ASTNode;
+import com.intellij.lang.LightPsiParser;
+import com.intellij.lang.PsiBuilder;
+import com.intellij.lang.PsiBuilder.Marker;
+import com.intellij.lang.PsiParser;
+import com.intellij.psi.tree.IElementType;
+import com.intellij.psi.tree.TokenSet;
+
 import static com.intellij.lang.parser.GeneratedParserUtilBase.TRUE_CONDITION;
 import static com.intellij.lang.parser.GeneratedParserUtilBase._AND_;
 import static com.intellij.lang.parser.GeneratedParserUtilBase._COLLAPSE_;
@@ -15,14 +23,6 @@ import static com.intellij.lang.parser.GeneratedParserUtilBase.exit_section_;
 import static com.intellij.lang.parser.GeneratedParserUtilBase.nextTokenIs;
 import static com.intellij.lang.parser.GeneratedParserUtilBase.recursion_guard_;
 import static tech.pantheon.yanginator.plugin.psi.YangTypes.*;
-
-import com.intellij.lang.ASTNode;
-import com.intellij.lang.LightPsiParser;
-import com.intellij.lang.PsiBuilder;
-import com.intellij.lang.PsiBuilder.Marker;
-import com.intellij.lang.PsiParser;
-import com.intellij.psi.tree.IElementType;
-import com.intellij.psi.tree.TokenSet;
 
 @SuppressWarnings({"SimplifiableIfStatement", "UnusedAssignment"})
 public class YangParser implements PsiParser, LightPsiParser {
@@ -11253,20 +11253,17 @@ public class YangParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // string-restrictions-body +
+  // string-restrictions-body *
   public static boolean string_restrictions(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "string_restrictions")) return false;
-    if (!nextTokenIs(b, "<string restrictions>", YANG_LENGTH_KEYWORD, YANG_PATTERN_KEYWORD)) return false;
-    boolean r;
     Marker m = enter_section_(b, l, _NONE_, YANG_STRING_RESTRICTIONS, "<string restrictions>");
-    r = string_restrictions_body(b, l + 1);
-    while (r) {
+    while (true) {
       int c = current_position_(b);
       if (!string_restrictions_body(b, l + 1)) break;
       if (!empty_element_parsed_guard_(b, "string_restrictions", c)) break;
     }
-    exit_section_(b, l, m, r, false, null);
-    return r;
+    exit_section_(b, l, m, true, false, null);
+    return true;
   }
 
   /* ********************************************************** */
@@ -11456,26 +11453,26 @@ public class YangParser implements PsiParser, LightPsiParser {
   /* ********************************************************** */
   // numerical-restrictions |
   //  decimal64-specification |
-  //  string-restrictions |
   //  enum-specification |
   //  leafref-specification |
   //  identityref-specification |
   //  instance-identifier-specification |
   //  bits-specification |
-  //  union-specification
+  //  union-specification |
+  //  string-restrictions
   public static boolean type_body_stmts(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "type_body_stmts")) return false;
     boolean r;
     Marker m = enter_section_(b, l, _NONE_, YANG_TYPE_BODY_STMTS, "<type body stmts>");
     r = numerical_restrictions(b, l + 1);
     if (!r) r = decimal64_specification(b, l + 1);
-    if (!r) r = string_restrictions(b, l + 1);
     if (!r) r = enum_specification(b, l + 1);
     if (!r) r = leafref_specification(b, l + 1);
     if (!r) r = identityref_specification(b, l + 1);
     if (!r) r = instance_identifier_specification(b, l + 1);
     if (!r) r = bits_specification(b, l + 1);
     if (!r) r = union_specification(b, l + 1);
+    if (!r) r = string_restrictions(b, l + 1);
     exit_section_(b, l, m, r, false, null);
     return r;
   }
@@ -11484,7 +11481,7 @@ public class YangParser implements PsiParser, LightPsiParser {
   // TYPE_KEYWORD sep identifier-ref-arg-quoted optsep
   //  ( SEMICOLON |
   //  ( LEFT_BRACE stmtsep
-  //  type-body-stmts + // + is not corresponding with rfc6020 (added additionally)
+  //  type-body-stmts // + is not corresponding with rfc6020 (added additionally)
   //  RIGHT_BRACE ) )
   public static boolean type_stmt(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "type_stmt")) return false;
@@ -11502,7 +11499,7 @@ public class YangParser implements PsiParser, LightPsiParser {
 
   // SEMICOLON |
   //  ( LEFT_BRACE stmtsep
-  //  type-body-stmts + // + is not corresponding with rfc6020 (added additionally)
+  //  type-body-stmts // + is not corresponding with rfc6020 (added additionally)
   //  RIGHT_BRACE )
   private static boolean type_stmt_4(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "type_stmt_4")) return false;
@@ -11515,7 +11512,7 @@ public class YangParser implements PsiParser, LightPsiParser {
   }
 
   // LEFT_BRACE stmtsep
-  //  type-body-stmts + // + is not corresponding with rfc6020 (added additionally)
+  //  type-body-stmts // + is not corresponding with rfc6020 (added additionally)
   //  RIGHT_BRACE
   private static boolean type_stmt_4_1(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "type_stmt_4_1")) return false;
@@ -11523,23 +11520,8 @@ public class YangParser implements PsiParser, LightPsiParser {
     Marker m = enter_section_(b);
     r = consumeToken(b, YANG_LEFT_BRACE);
     r = r && stmtsep(b, l + 1);
-    r = r && type_stmt_4_1_2(b, l + 1);
+    r = r && type_body_stmts(b, l + 1);
     r = r && consumeToken(b, YANG_RIGHT_BRACE);
-    exit_section_(b, m, null, r);
-    return r;
-  }
-
-  // type-body-stmts +
-  private static boolean type_stmt_4_1_2(PsiBuilder b, int l) {
-    if (!recursion_guard_(b, l, "type_stmt_4_1_2")) return false;
-    boolean r;
-    Marker m = enter_section_(b);
-    r = type_body_stmts(b, l + 1);
-    while (r) {
-      int c = current_position_(b);
-      if (!type_body_stmts(b, l + 1)) break;
-      if (!empty_element_parsed_guard_(b, "type_stmt_4_1_2", c)) break;
-    }
     exit_section_(b, m, null, r);
     return r;
   }

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangAbsolutePath.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangAbsolutePath.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangAbsolutePath extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangAbsoluteSchemaNodeid.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangAbsoluteSchemaNodeid.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangAbsoluteSchemaNodeid extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangAbsoluteSchemaNodeidQuoted.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangAbsoluteSchemaNodeidQuoted.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangAbsoluteSchemaNodeidQuoted extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangAnyxmlStmt.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangAnyxmlStmt.java
@@ -2,9 +2,10 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public interface YangAnyxmlStmt extends YangStatement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangArgumentStmt.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangArgumentStmt.java
@@ -2,9 +2,10 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public interface YangArgumentStmt extends YangStatement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangAugmentStmt.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangAugmentStmt.java
@@ -2,8 +2,9 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangAugmentStmt extends YangStatement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangBelongsToStmt.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangBelongsToStmt.java
@@ -2,8 +2,9 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangBelongsToStmt extends YangStatement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangBitStmt.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangBitStmt.java
@@ -2,9 +2,10 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public interface YangBitStmt extends YangStatement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangBitsSpecification.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangBitsSpecification.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangBitsSpecification extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangBodyStmts.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangBodyStmts.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangBodyStmts extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangCaseStmt.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangCaseStmt.java
@@ -2,9 +2,10 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public interface YangCaseStmt extends YangStatement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangChoiceStmt.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangChoiceStmt.java
@@ -2,9 +2,10 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public interface YangChoiceStmt extends YangStatement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangContainerStmt.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangContainerStmt.java
@@ -2,9 +2,10 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public interface YangContainerStmt extends YangStatement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangCr.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangCr.java
@@ -2,8 +2,9 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangCr extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangCurrentFunctionInvocation.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangCurrentFunctionInvocation.java
@@ -2,9 +2,10 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public interface YangCurrentFunctionInvocation extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangDateArg.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangDateArg.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangDateArg extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangDateArgQuoted.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangDateArgQuoted.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangDateArgQuoted extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangDescendantPath.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangDescendantPath.java
@@ -1,9 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public interface YangDescendantPath extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangDeviateAddStmt.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangDeviateAddStmt.java
@@ -2,9 +2,10 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public interface YangDeviateAddStmt extends YangStatement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangDeviateDeleteStmt.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangDeviateDeleteStmt.java
@@ -2,9 +2,10 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public interface YangDeviateDeleteStmt extends YangStatement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangDeviateReplaceStmt.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangDeviateReplaceStmt.java
@@ -2,9 +2,10 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public interface YangDeviateReplaceStmt extends YangStatement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangDeviationStmt.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangDeviationStmt.java
@@ -2,8 +2,9 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangDeviationStmt extends YangStatement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangDeviationStmtBody.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangDeviationStmtBody.java
@@ -1,9 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public interface YangDeviationStmtBody extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangEnumSpecification.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangEnumSpecification.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangEnumSpecification extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangEnumStmt.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangEnumStmt.java
@@ -2,9 +2,10 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public interface YangEnumStmt extends YangStatement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangExtensionStmt.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangExtensionStmt.java
@@ -2,9 +2,10 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public interface YangExtensionStmt extends YangStatement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangFeatureStmt.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangFeatureStmt.java
@@ -2,9 +2,10 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public interface YangFeatureStmt extends YangStatement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangGroupingStmt.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangGroupingStmt.java
@@ -2,10 +2,11 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.reference.YangGeneratedReferenceType;
+
+import java.util.List;
 
 public interface YangGroupingStmt extends YangGeneratedReferenceType {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangH16.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangH16.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangH16 extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangHtab.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangHtab.java
@@ -2,9 +2,10 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public interface YangHtab extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangIPv4Address.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangIPv4Address.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangIPv4Address extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangIPv6Address.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangIPv6Address.java
@@ -1,9 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public interface YangIPv6Address extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangIPvFuture.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangIPvFuture.java
@@ -2,8 +2,9 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangIPvFuture extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangIdentifierQuoted.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangIdentifierQuoted.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangIdentifierQuoted extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangIdentityStmt.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangIdentityStmt.java
@@ -2,10 +2,11 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.reference.YangGeneratedReferenceType;
+
+import java.util.List;
 
 public interface YangIdentityStmt extends YangGeneratedReferenceType {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangImportStmt.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangImportStmt.java
@@ -2,8 +2,9 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangImportStmt extends YangStatement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangIncludeStmt.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangIncludeStmt.java
@@ -2,9 +2,10 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public interface YangIncludeStmt extends YangStatement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangInputStmt.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangInputStmt.java
@@ -2,8 +2,9 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangInputStmt extends YangStatement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangInstanceIdentifier.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangInstanceIdentifier.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangInstanceIdentifier extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangKeyArg.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangKeyArg.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangKeyArg extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangLeafListStmt.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangLeafListStmt.java
@@ -2,8 +2,9 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangLeafListStmt extends YangStatement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangLeafStmt.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangLeafStmt.java
@@ -2,8 +2,9 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangLeafStmt extends YangStatement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangLeafrefSpecification.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangLeafrefSpecification.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangLeafrefSpecification extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangLengthArg.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangLengthArg.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangLengthArg extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangLengthPart.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangLengthPart.java
@@ -2,9 +2,10 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public interface YangLengthPart extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangLengthStmt.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangLengthStmt.java
@@ -2,9 +2,10 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public interface YangLengthStmt extends YangStatement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangLineComment.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangLineComment.java
@@ -2,9 +2,10 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public interface YangLineComment extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangLinkageStmts.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangLinkageStmts.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangLinkageStmts extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangListStmt.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangListStmt.java
@@ -2,8 +2,9 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangListStmt extends YangStatement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangLs32.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangLs32.java
@@ -1,9 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public interface YangLs32 extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangMetaStmts.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangMetaStmts.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangMetaStmts extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangModuleHeaderStmts.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangModuleHeaderStmts.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangModuleHeaderStmts extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangModuleStmt.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangModuleStmt.java
@@ -2,9 +2,10 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public interface YangModuleStmt extends YangStatement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangMustStmt.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangMustStmt.java
@@ -2,9 +2,10 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public interface YangMustStmt extends YangStatement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangNodeIdentifierQuoted.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangNodeIdentifierQuoted.java
@@ -2,9 +2,10 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public interface YangNodeIdentifierQuoted extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangNonQuotedString.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangNonQuotedString.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangNonQuotedString extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangNotificationStmt.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangNotificationStmt.java
@@ -2,9 +2,10 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public interface YangNotificationStmt extends YangStatement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangOptsep.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangOptsep.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangOptsep extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangOutputStmt.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangOutputStmt.java
@@ -2,8 +2,9 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangOutputStmt extends YangStatement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangPathAbempty.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangPathAbempty.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangPathAbempty extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangPathAbsolute.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangPathAbsolute.java
@@ -1,9 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public interface YangPathAbsolute extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangPathEqualityExpr.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangPathEqualityExpr.java
@@ -2,8 +2,9 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangPathEqualityExpr extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangPathKeyExpr.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangPathKeyExpr.java
@@ -2,8 +2,9 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangPathKeyExpr extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangPathPredicate.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangPathPredicate.java
@@ -2,8 +2,9 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangPathPredicate extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangPathRootless.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangPathRootless.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangPathRootless extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangPatternStmt.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangPatternStmt.java
@@ -2,9 +2,10 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public interface YangPatternStmt extends YangStatement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangPctEncoded.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangPctEncoded.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangPctEncoded extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangPort.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangPort.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangPort extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangPositiveIntegerValue.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangPositiveIntegerValue.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangPositiveIntegerValue extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangPredicate.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangPredicate.java
@@ -2,8 +2,9 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangPredicate extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangPredicateExpr.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangPredicateExpr.java
@@ -2,9 +2,10 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public interface YangPredicateExpr extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangQuery.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangQuery.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangQuery extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangRangeArg.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangRangeArg.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangRangeArg extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangRangePart.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangRangePart.java
@@ -2,9 +2,10 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public interface YangRangePart extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangRangeStmt.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangRangeStmt.java
@@ -2,9 +2,10 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public interface YangRangeStmt extends YangStatement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangRefineAnyxmlStmts.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangRefineAnyxmlStmts.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangRefineAnyxmlStmts extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangRefineCaseStmts.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangRefineCaseStmts.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangRefineCaseStmts extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangRefineChoiceStmts.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangRefineChoiceStmts.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangRefineChoiceStmts extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangRefineContainerStmts.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangRefineContainerStmts.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangRefineContainerStmts extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangRefineLeafListStmts.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangRefineLeafListStmts.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangRefineLeafListStmts extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangRefineLeafStmts.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangRefineLeafStmts.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangRefineLeafStmts extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangRefineListStmts.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangRefineListStmts.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangRefineListStmts extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangRegName.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangRegName.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangRegName extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangRelPathKeyexpr.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangRelPathKeyexpr.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangRelPathKeyexpr extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangRelativePath.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangRelativePath.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangRelativePath extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangRevisionStmt.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangRevisionStmt.java
@@ -2,9 +2,10 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public interface YangRevisionStmt extends YangStatement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangRevisionStmts.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangRevisionStmts.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangRevisionStmts extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangRpcStmt.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangRpcStmt.java
@@ -2,9 +2,10 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public interface YangRpcStmt extends YangStatement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangScheme.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangScheme.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangScheme extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangSegment.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangSegment.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangSegment extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangSegmentNz.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangSegmentNz.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangSegmentNz extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangSep.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangSep.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangSep extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangSingleQuoteStringSplitter.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangSingleQuoteStringSplitter.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangSingleQuoteStringSplitter extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangSplittedCurrentKeyword.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangSplittedCurrentKeyword.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangSplittedCurrentKeyword extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangStmtend.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangStmtend.java
@@ -2,9 +2,10 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public interface YangStmtend extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangStmtsep.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangStmtsep.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangStmtsep extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangString.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangString.java
@@ -1,9 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public interface YangString extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangStringRestrictions.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangStringRestrictions.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangStringRestrictions extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangStringSplitter.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangStringSplitter.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangStringSplitter extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangSubmoduleHeaderStmts.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangSubmoduleHeaderStmts.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangSubmoduleHeaderStmts extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangSubmoduleStmt.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangSubmoduleStmt.java
@@ -2,9 +2,10 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public interface YangSubmoduleStmt extends YangStatement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangTypeStmt.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangTypeStmt.java
@@ -2,7 +2,6 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.reference.YangGeneratedReferenceType;
@@ -21,8 +20,8 @@ public interface YangTypeStmt extends YangGeneratedReferenceType {
   @Nullable
   YangStmtsep getStmtsep();
 
-  @NotNull
-  List<YangTypeBodyStmts> getTypeBodyStmtsList();
+  @Nullable
+  YangTypeBodyStmts getTypeBodyStmts();
 
   @Nullable
   PsiElement getLeftBrace();

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangTypedefStmt.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangTypedefStmt.java
@@ -2,9 +2,10 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.reference.YangGeneratedReferenceType;
+
+import java.util.List;
 
 public interface YangTypedefStmt extends YangGeneratedReferenceType {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangUnionSpecification.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangUnionSpecification.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangUnionSpecification extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangUniqueArg.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangUniqueArg.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangUniqueArg extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangUnknownStatement.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangUnknownStatement.java
@@ -2,9 +2,10 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public interface YangUnknownStatement extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangUnknownStatement2.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangUnknownStatement2.java
@@ -2,9 +2,10 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public interface YangUnknownStatement2 extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangUserinfo.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangUserinfo.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangUserinfo extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangUsesAugmentStmt.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangUsesAugmentStmt.java
@@ -2,8 +2,9 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangUsesAugmentStmt extends YangStatement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangUsesStmt.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangUsesStmt.java
@@ -2,10 +2,11 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.reference.YangGeneratedReferenceType;
+
+import java.util.List;
 
 public interface YangUsesStmt extends YangGeneratedReferenceType {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangWhenStmt.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangWhenStmt.java
@@ -2,9 +2,10 @@
 package tech.pantheon.yanginator.plugin.psi;
 
 import com.intellij.psi.PsiElement;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public interface YangWhenStmt extends YangStatement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangZeroIntegerValue.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/YangZeroIntegerValue.java
@@ -1,8 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi;
 
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 public interface YangZeroIntegerValue extends YangNamedElement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangAbsolutePathImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangAbsolutePathImpl.java
@@ -4,12 +4,13 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangAbsolutePath;
 import tech.pantheon.yanginator.plugin.psi.YangNodeIdentifier;
 import tech.pantheon.yanginator.plugin.psi.YangPathPredicate;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangAbsolutePathImpl extends YangNamedElementImpl implements YangAbsolutePath {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangAbsoluteSchemaNodeidImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangAbsoluteSchemaNodeidImpl.java
@@ -4,11 +4,12 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangAbsoluteSchemaNodeid;
 import tech.pantheon.yanginator.plugin.psi.YangNodeIdentifier;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangAbsoluteSchemaNodeidImpl extends YangNamedElementImpl implements YangAbsoluteSchemaNodeid {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangAbsoluteSchemaNodeidQuotedImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangAbsoluteSchemaNodeidQuotedImpl.java
@@ -4,12 +4,13 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangAbsoluteSchemaNodeidQuoted;
 import tech.pantheon.yanginator.plugin.psi.YangNodeIdentifierQuoted;
 import tech.pantheon.yanginator.plugin.psi.YangStringSplitter;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangAbsoluteSchemaNodeidQuotedImpl extends YangNamedElementImpl implements YangAbsoluteSchemaNodeidQuoted {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangAnyxmlStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangAnyxmlStmtImpl.java
@@ -1,16 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_ANYXML_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangAnyxmlStmt;
@@ -20,6 +14,13 @@ import tech.pantheon.yanginator.plugin.psi.YangOptsep;
 import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_ANYXML_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
 
 public class YangAnyxmlStmtImpl extends YangStatementImpl implements YangAnyxmlStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangArgumentStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangArgumentStmtImpl.java
@@ -1,16 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_ARGUMENT_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangArgumentStmt;
@@ -20,6 +14,13 @@ import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
 import tech.pantheon.yanginator.plugin.psi.YangYinElementStmt;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_ARGUMENT_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
 
 public class YangArgumentStmtImpl extends YangStatementImpl implements YangArgumentStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangAugmentStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangAugmentStmtImpl.java
@@ -1,15 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_AUGMENT_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangAugmentArgStr;
 import tech.pantheon.yanginator.plugin.psi.YangAugmentStmt;
@@ -18,6 +13,12 @@ import tech.pantheon.yanginator.plugin.psi.YangOptsep;
 import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_AUGMENT_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
 
 public class YangAugmentStmtImpl extends YangStatementImpl implements YangAugmentStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangAuthorityImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangAuthorityImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_COLON;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -13,6 +11,8 @@ import tech.pantheon.yanginator.plugin.psi.YangHost;
 import tech.pantheon.yanginator.plugin.psi.YangPort;
 import tech.pantheon.yanginator.plugin.psi.YangUserinfo;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_COLON;
 
 public class YangAuthorityImpl extends YangNamedElementImpl implements YangAuthority {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangBaseStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangBaseStmtImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_BASE_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -14,6 +12,8 @@ import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtend;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
 import tech.pantheon.yanginator.plugin.reference.YangGeneratedReferenceTypeImpl;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_BASE_KEYWORD;
 
 public class YangBaseStmtImpl extends YangGeneratedReferenceTypeImpl implements YangBaseStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangBelongsToStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangBelongsToStmtImpl.java
@@ -1,15 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_BELONGS_TO_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangBelongsToStmt;
 import tech.pantheon.yanginator.plugin.psi.YangIdentifierArgQuoted;
@@ -18,6 +13,12 @@ import tech.pantheon.yanginator.plugin.psi.YangPrefixStmt;
 import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_BELONGS_TO_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
 
 public class YangBelongsToStmtImpl extends YangStatementImpl implements YangBelongsToStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangBitStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangBitStmtImpl.java
@@ -1,16 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_BIT_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangBitStmt;
@@ -20,6 +14,13 @@ import tech.pantheon.yanginator.plugin.psi.YangOptsep;
 import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_BIT_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
 
 public class YangBitStmtImpl extends YangStatementImpl implements YangBitStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangBitsSpecificationImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangBitsSpecificationImpl.java
@@ -4,12 +4,13 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangBitStmt;
 import tech.pantheon.yanginator.plugin.psi.YangBitsSpecification;
 import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangBitsSpecificationImpl extends YangNamedElementImpl implements YangBitsSpecification {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangBodyStmtsImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangBodyStmtsImpl.java
@@ -4,7 +4,6 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangBodyStmts;
 import tech.pantheon.yanginator.plugin.psi.YangGroupingStmt;
@@ -13,6 +12,8 @@ import tech.pantheon.yanginator.plugin.psi.YangStatement;
 import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangTypedefStmt;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangBodyStmtsImpl extends YangNamedElementImpl implements YangBodyStmts {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangCaseStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangCaseStmtImpl.java
@@ -1,16 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_CASE_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangCaseStmt;
@@ -20,6 +14,13 @@ import tech.pantheon.yanginator.plugin.psi.YangOptsep;
 import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_CASE_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
 
 public class YangCaseStmtImpl extends YangStatementImpl implements YangCaseStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangChoiceStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangChoiceStmtImpl.java
@@ -1,16 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_CHOICE_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangChoiceStmt;
@@ -20,6 +14,13 @@ import tech.pantheon.yanginator.plugin.psi.YangOptsep;
 import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_CHOICE_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
 
 public class YangChoiceStmtImpl extends YangStatementImpl implements YangChoiceStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangCommentImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangCommentImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_BLOCK_COMMENT;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -11,6 +9,8 @@ import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangComment;
 import tech.pantheon.yanginator.plugin.psi.YangLineComment;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_BLOCK_COMMENT;
 
 public class YangCommentImpl extends YangNamedElementImpl implements YangComment {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangConfigArgImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangConfigArgImpl.java
@@ -1,9 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_FALSE_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_TRUE_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -11,6 +8,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangConfigArg;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_FALSE_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_TRUE_KEYWORD;
 
 public class YangConfigArgImpl extends YangNamedElementImpl implements YangConfigArg {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangConfigStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangConfigStmtImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_CONFIG_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -12,6 +10,8 @@ import tech.pantheon.yanginator.plugin.psi.YangConfigStmt;
 import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtend;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_CONFIG_KEYWORD;
 
 public class YangConfigStmtImpl extends YangStatementImpl implements YangConfigStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangContactStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangContactStmtImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_CONTACT_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -13,6 +11,8 @@ import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtend;
 import tech.pantheon.yanginator.plugin.psi.YangString;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_CONTACT_KEYWORD;
 
 public class YangContactStmtImpl extends YangStatementImpl implements YangContactStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangContainerStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangContainerStmtImpl.java
@@ -1,16 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_CONTAINER_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangContainerStmt;
@@ -20,6 +14,13 @@ import tech.pantheon.yanginator.plugin.psi.YangOptsep;
 import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_CONTAINER_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
 
 public class YangContainerStmtImpl extends YangStatementImpl implements YangContainerStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangCrImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangCrImpl.java
@@ -1,17 +1,18 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_CARRIAGE_RETURN;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangComment;
 import tech.pantheon.yanginator.plugin.psi.YangCr;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_CARRIAGE_RETURN;
 
 public class YangCrImpl extends YangNamedElementImpl implements YangCr {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangCurrentFunctionInvocationImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangCurrentFunctionInvocationImpl.java
@@ -1,15 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_CURRENT_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_PARENTHESIS;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_PARENTHESIS;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangCurrentFunctionInvocation;
@@ -17,6 +12,12 @@ import tech.pantheon.yanginator.plugin.psi.YangSplittedCurrentKeyword;
 import tech.pantheon.yanginator.plugin.psi.YangStringSplitter;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
 import tech.pantheon.yanginator.plugin.psi.YangWsp;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_CURRENT_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_PARENTHESIS;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_PARENTHESIS;
 
 public class YangCurrentFunctionInvocationImpl extends YangNamedElementImpl implements YangCurrentFunctionInvocation {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangDateArgImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangDateArgImpl.java
@@ -4,12 +4,13 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangDateArg;
 import tech.pantheon.yanginator.plugin.psi.YangDigit;
 import tech.pantheon.yanginator.plugin.psi.YangStringSplitter;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangDateArgImpl extends YangNamedElementImpl implements YangDateArg {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangDateArgQuotedImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangDateArgQuotedImpl.java
@@ -4,11 +4,12 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangDateArgQuoted;
 import tech.pantheon.yanginator.plugin.psi.YangDigit;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangDateArgQuotedImpl extends YangNamedElementImpl implements YangDateArgQuoted {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangDecimalValueImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangDecimalValueImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_DOT;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -11,6 +9,8 @@ import tech.pantheon.yanginator.plugin.psi.YangDecimalValue;
 import tech.pantheon.yanginator.plugin.psi.YangIntegerValue;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
 import tech.pantheon.yanginator.plugin.psi.YangZeroIntegerValue;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_DOT;
 
 public class YangDecimalValueImpl extends YangNamedElementImpl implements YangDecimalValue {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangDefaultStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangDefaultStmtImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_DEFAULT_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -12,6 +10,8 @@ import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtend;
 import tech.pantheon.yanginator.plugin.psi.YangString;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_DEFAULT_KEYWORD;
 
 public class YangDefaultStmtImpl extends YangStatementImpl implements YangDefaultStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangDescendantPathImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangDescendantPathImpl.java
@@ -4,7 +4,6 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangAbsolutePath;
@@ -12,6 +11,8 @@ import tech.pantheon.yanginator.plugin.psi.YangDescendantPath;
 import tech.pantheon.yanginator.plugin.psi.YangNodeIdentifier;
 import tech.pantheon.yanginator.plugin.psi.YangPathPredicate;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangDescendantPathImpl extends YangNamedElementImpl implements YangDescendantPath {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangDescriptionStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangDescriptionStmtImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_DESCRIPTION_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -13,6 +11,8 @@ import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtend;
 import tech.pantheon.yanginator.plugin.psi.YangString;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_DESCRIPTION_KEYWORD;
 
 public class YangDescriptionStmtImpl extends YangStatementImpl implements YangDescriptionStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangDeviateAddStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangDeviateAddStmtImpl.java
@@ -1,17 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_ADD_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_DEVIATE_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangDeviateAddStmt;
@@ -20,6 +13,14 @@ import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStatement;
 import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_ADD_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_DEVIATE_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
 
 public class YangDeviateAddStmtImpl extends YangStatementImpl implements YangDeviateAddStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangDeviateDeleteStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangDeviateDeleteStmtImpl.java
@@ -1,17 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_DELETE_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_DEVIATE_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangDeviateDeleteStmt;
@@ -20,6 +13,14 @@ import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStatement;
 import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_DELETE_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_DEVIATE_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
 
 public class YangDeviateDeleteStmtImpl extends YangStatementImpl implements YangDeviateDeleteStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangDeviateNotSupportedStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangDeviateNotSupportedStmtImpl.java
@@ -1,12 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_DEVIATE_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_NOT_SUPPORTED_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -17,6 +11,12 @@ import tech.pantheon.yanginator.plugin.psi.YangOptsep;
 import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_DEVIATE_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_NOT_SUPPORTED_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
 
 public class YangDeviateNotSupportedStmtImpl extends YangStatementImpl implements YangDeviateNotSupportedStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangDeviateReplaceStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangDeviateReplaceStmtImpl.java
@@ -1,17 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_DEVIATE_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_REPLACE_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangDeviateReplaceStmt;
@@ -20,6 +13,14 @@ import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStatement;
 import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_DEVIATE_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_REPLACE_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
 
 public class YangDeviateReplaceStmtImpl extends YangStatementImpl implements YangDeviateReplaceStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangDeviationStmtBodyImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangDeviationStmtBodyImpl.java
@@ -4,13 +4,14 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangDeviationStmtBody;
 import tech.pantheon.yanginator.plugin.psi.YangStatement;
 import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangDeviationStmtBodyImpl extends YangNamedElementImpl implements YangDeviationStmtBody {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangDeviationStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangDeviationStmtImpl.java
@@ -1,15 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_DEVIATION_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangDeviationArgStr;
 import tech.pantheon.yanginator.plugin.psi.YangDeviationStmt;
@@ -18,6 +13,12 @@ import tech.pantheon.yanginator.plugin.psi.YangOptsep;
 import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_DEVIATION_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
 
 public class YangDeviationStmtImpl extends YangStatementImpl implements YangDeviationStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangDigitImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangDigitImpl.java
@@ -1,9 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_POSITIVE_NUMBER;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_ZERO;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -11,6 +8,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangDigit;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_POSITIVE_NUMBER;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_ZERO;
 
 public class YangDigitImpl extends YangNamedElementImpl implements YangDigit {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangEnumSpecificationImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangEnumSpecificationImpl.java
@@ -4,12 +4,13 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangEnumSpecification;
 import tech.pantheon.yanginator.plugin.psi.YangEnumStmt;
 import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangEnumSpecificationImpl extends YangNamedElementImpl implements YangEnumSpecification {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangEnumStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangEnumStmtImpl.java
@@ -1,16 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_ENUM_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangEnumStmt;
@@ -20,6 +14,13 @@ import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangString;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_ENUM_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
 
 public class YangEnumStmtImpl extends YangStatementImpl implements YangEnumStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangErrorAppTagStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangErrorAppTagStmtImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_ERROR_APP_TAG_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -12,6 +10,8 @@ import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtend;
 import tech.pantheon.yanginator.plugin.psi.YangString;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_ERROR_APP_TAG_KEYWORD;
 
 public class YangErrorAppTagStmtImpl extends YangStatementImpl implements YangErrorAppTagStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangErrorMessageStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangErrorMessageStmtImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_ERROR_MESSAGE_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -12,6 +10,8 @@ import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtend;
 import tech.pantheon.yanginator.plugin.psi.YangString;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_ERROR_MESSAGE_KEYWORD;
 
 public class YangErrorMessageStmtImpl extends YangStatementImpl implements YangErrorMessageStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangExtensionStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangExtensionStmtImpl.java
@@ -1,16 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_EXTENSION_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangExtensionStmt;
@@ -20,6 +14,13 @@ import tech.pantheon.yanginator.plugin.psi.YangOptsep;
 import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_EXTENSION_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
 
 public class YangExtensionStmtImpl extends YangStatementImpl implements YangExtensionStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangFeatureStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangFeatureStmtImpl.java
@@ -1,16 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_FEATURE_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangFeatureStmt;
@@ -20,6 +14,13 @@ import tech.pantheon.yanginator.plugin.psi.YangOptsep;
 import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_FEATURE_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
 
 public class YangFeatureStmtImpl extends YangStatementImpl implements YangFeatureStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangFractionDigitsArgImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangFractionDigitsArgImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_ZERO;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -10,6 +8,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangFractionDigitsArg;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_ZERO;
 
 public class YangFractionDigitsArgImpl extends YangNamedElementImpl implements YangFractionDigitsArg {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangFractionDigitsStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangFractionDigitsStmtImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_FRACTION_DIGITS_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -12,6 +10,8 @@ import tech.pantheon.yanginator.plugin.psi.YangFractionDigitsStmt;
 import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtend;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_FRACTION_DIGITS_KEYWORD;
 
 public class YangFractionDigitsStmtImpl extends YangStatementImpl implements YangFractionDigitsStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangGroupingStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangGroupingStmtImpl.java
@@ -1,16 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_GROUPING_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangGroupingStmt;
@@ -21,6 +15,13 @@ import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
 import tech.pantheon.yanginator.plugin.reference.YangGeneratedReferenceTypeImpl;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_GROUPING_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
 
 public class YangGroupingStmtImpl extends YangGeneratedReferenceTypeImpl implements YangGroupingStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangH16Impl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangH16Impl.java
@@ -4,11 +4,12 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangH16;
 import tech.pantheon.yanginator.plugin.psi.YangHexdig;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangH16Impl extends YangNamedElementImpl implements YangH16 {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangHIdentifierLiteralImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangHIdentifierLiteralImpl.java
@@ -1,6 +1,14 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiElementVisitor;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import tech.pantheon.yanginator.plugin.psi.YangHIdentifierLiteral;
+import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
 import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_H_ADD_KEYWORD;
 import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_H_ANYXML_KEYWORD;
 import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_H_ARGUMENT_KEYWORD;
@@ -81,14 +89,6 @@ import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_H_VALUE_KEYWORD
 import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_H_WHEN_KEYWORD;
 import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_H_YANG_VERSION_KEYWORD;
 import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_H_YIN_ELEMENT_KEYWORD;
-
-import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
-import com.intellij.psi.PsiElementVisitor;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import tech.pantheon.yanginator.plugin.psi.YangHIdentifierLiteral;
-import tech.pantheon.yanginator.plugin.psi.YangVisitor;
 
 public class YangHIdentifierLiteralImpl extends YangNamedElementImpl implements YangHIdentifierLiteral {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangHighlighterTokensImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangHighlighterTokensImpl.java
@@ -1,6 +1,14 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiElementVisitor;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import tech.pantheon.yanginator.plugin.psi.YangHighlighterTokens;
+import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
 import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_BLOCK_COMMENT_END;
 import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_H_A;
 import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_H_BLOCK_COMMENT;
@@ -12,14 +20,6 @@ import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_H_NOT_STRING;
 import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_H_SINGLE_LINE_COMMENT;
 import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_H_STRING;
 import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_H_WHITE_SPACE;
-
-import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
-import com.intellij.psi.PsiElementVisitor;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import tech.pantheon.yanginator.plugin.psi.YangHighlighterTokens;
-import tech.pantheon.yanginator.plugin.psi.YangVisitor;
 
 public class YangHighlighterTokensImpl extends YangNamedElementImpl implements YangHighlighterTokens {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangHtabImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangHtabImpl.java
@@ -1,18 +1,19 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_TAB;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangHtab;
 import tech.pantheon.yanginator.plugin.psi.YangSp;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_TAB;
 
 public class YangHtabImpl extends YangNamedElementImpl implements YangHtab {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangIPLiteralImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangIPLiteralImpl.java
@@ -1,9 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_CLOSED_BRACKET;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_OPEN_BRACKET;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -13,6 +10,9 @@ import tech.pantheon.yanginator.plugin.psi.YangIPLiteral;
 import tech.pantheon.yanginator.plugin.psi.YangIPv6Address;
 import tech.pantheon.yanginator.plugin.psi.YangIPvFuture;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_CLOSED_BRACKET;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_OPEN_BRACKET;
 
 public class YangIPLiteralImpl extends YangNamedElementImpl implements YangIPLiteral {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangIPv4AddressImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangIPv4AddressImpl.java
@@ -4,11 +4,12 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangDecOctet;
 import tech.pantheon.yanginator.plugin.psi.YangIPv4Address;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangIPv4AddressImpl extends YangNamedElementImpl implements YangIPv4Address {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangIPv6AddressImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangIPv6AddressImpl.java
@@ -4,13 +4,14 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangH16;
 import tech.pantheon.yanginator.plugin.psi.YangIPv6Address;
 import tech.pantheon.yanginator.plugin.psi.YangLs32;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangIPv6AddressImpl extends YangNamedElementImpl implements YangIPv6Address {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangIPvFutureImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangIPvFutureImpl.java
@@ -1,19 +1,20 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_DOT;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangHexdig;
 import tech.pantheon.yanginator.plugin.psi.YangIPvFuture;
 import tech.pantheon.yanginator.plugin.psi.YangSubDelims;
 import tech.pantheon.yanginator.plugin.psi.YangUnreserved;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_DOT;
 
 public class YangIPvFutureImpl extends YangNamedElementImpl implements YangIPvFuture {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangIdentifierLiteralImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangIdentifierLiteralImpl.java
@@ -1,6 +1,14 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiElementVisitor;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import tech.pantheon.yanginator.plugin.psi.YangIdentifierLiteral;
+import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
 import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_ADD_KEYWORD;
 import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_ANYXML_KEYWORD;
 import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_ARGUMENT_KEYWORD;
@@ -80,14 +88,6 @@ import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_VALUE_KEYWORD;
 import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_WHEN_KEYWORD;
 import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_YANG_VERSION_KEYWORD;
 import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_YIN_ELEMENT_KEYWORD;
-
-import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
-import com.intellij.psi.PsiElementVisitor;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import tech.pantheon.yanginator.plugin.psi.YangIdentifierLiteral;
-import tech.pantheon.yanginator.plugin.psi.YangVisitor;
 
 public class YangIdentifierLiteralImpl extends YangNamedElementImpl implements YangIdentifierLiteral {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangIdentifierQuotedImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangIdentifierQuotedImpl.java
@@ -4,13 +4,14 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangDigit;
 import tech.pantheon.yanginator.plugin.psi.YangIdentifierLiteral;
 import tech.pantheon.yanginator.plugin.psi.YangIdentifierQuoted;
 import tech.pantheon.yanginator.plugin.psi.YangStringSplitter;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangIdentifierQuotedImpl extends YangNamedElementImpl implements YangIdentifierQuoted {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangIdentifierRefArgImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangIdentifierRefArgImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_COLON;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -12,6 +10,8 @@ import tech.pantheon.yanginator.plugin.psi.YangIdentifier;
 import tech.pantheon.yanginator.plugin.psi.YangIdentifierRefArg;
 import tech.pantheon.yanginator.plugin.psi.YangPrefix;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_COLON;
 
 public class YangIdentifierRefArgImpl extends YangNamedElementImpl implements YangIdentifierRefArg {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangIdentityStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangIdentityStmtImpl.java
@@ -1,16 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_IDENTITY_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangIdentifierArgQuoted;
@@ -21,6 +15,13 @@ import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
 import tech.pantheon.yanginator.plugin.reference.YangGeneratedReferenceTypeImpl;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_IDENTITY_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
 
 public class YangIdentityStmtImpl extends YangGeneratedReferenceTypeImpl implements YangIdentityStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangIfFeatureStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangIfFeatureStmtImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_IF_FEATURE_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -13,6 +11,8 @@ import tech.pantheon.yanginator.plugin.psi.YangOptsep;
 import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtend;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_IF_FEATURE_KEYWORD;
 
 public class YangIfFeatureStmtImpl extends YangStatementImpl implements YangIfFeatureStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangImportStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangImportStmtImpl.java
@@ -1,15 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_IMPORT_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangIdentifierArgQuoted;
 import tech.pantheon.yanginator.plugin.psi.YangImportStmt;
@@ -18,6 +13,12 @@ import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStatement;
 import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_IMPORT_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
 
 public class YangImportStmtImpl extends YangStatementImpl implements YangImportStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangIncludeStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangIncludeStmtImpl.java
@@ -1,16 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_INCLUDE_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangIdentifierArgQuoted;
@@ -20,6 +14,13 @@ import tech.pantheon.yanginator.plugin.psi.YangRevisionDateStmt;
 import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_INCLUDE_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
 
 public class YangIncludeStmtImpl extends YangStatementImpl implements YangIncludeStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangInputStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangInputStmtImpl.java
@@ -1,21 +1,22 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_INPUT_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangInputStmt;
 import tech.pantheon.yanginator.plugin.psi.YangInputStmtBody;
 import tech.pantheon.yanginator.plugin.psi.YangOptsep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_INPUT_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
 
 public class YangInputStmtImpl extends YangStatementImpl implements YangInputStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangInstanceIdentifierImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangInstanceIdentifierImpl.java
@@ -4,12 +4,13 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangInstanceIdentifier;
 import tech.pantheon.yanginator.plugin.psi.YangNodeIdentifier;
 import tech.pantheon.yanginator.plugin.psi.YangPredicate;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangInstanceIdentifierImpl extends YangNamedElementImpl implements YangInstanceIdentifier {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangKeyArgImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangKeyArgImpl.java
@@ -4,12 +4,13 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangKeyArg;
 import tech.pantheon.yanginator.plugin.psi.YangNodeIdentifier;
 import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangKeyArgImpl extends YangNamedElementImpl implements YangKeyArg {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangKeyStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangKeyStmtImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_KEY_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -12,6 +10,8 @@ import tech.pantheon.yanginator.plugin.psi.YangKeyStmt;
 import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtend;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_KEY_KEYWORD;
 
 public class YangKeyStmtImpl extends YangStatementImpl implements YangKeyStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangLeafListStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangLeafListStmtImpl.java
@@ -1,15 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEAF_LIST_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangIdentifierArgQuoted;
 import tech.pantheon.yanginator.plugin.psi.YangLeafListStmt;
@@ -18,6 +13,12 @@ import tech.pantheon.yanginator.plugin.psi.YangOptsep;
 import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEAF_LIST_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
 
 public class YangLeafListStmtImpl extends YangStatementImpl implements YangLeafListStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangLeafStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangLeafStmtImpl.java
@@ -1,15 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEAF_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangIdentifierArgQuoted;
 import tech.pantheon.yanginator.plugin.psi.YangLeafStmt;
@@ -18,6 +13,12 @@ import tech.pantheon.yanginator.plugin.psi.YangOptsep;
 import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEAF_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
 
 public class YangLeafStmtImpl extends YangStatementImpl implements YangLeafStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangLeafrefSpecificationImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangLeafrefSpecificationImpl.java
@@ -4,11 +4,12 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangLeafrefSpecification;
 import tech.pantheon.yanginator.plugin.psi.YangLeafrefSpecificationBody;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangLeafrefSpecificationImpl extends YangNamedElementImpl implements YangLeafrefSpecification {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangLengthArgImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangLengthArgImpl.java
@@ -4,12 +4,13 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangLengthArg;
 import tech.pantheon.yanginator.plugin.psi.YangLengthPart;
 import tech.pantheon.yanginator.plugin.psi.YangOptsep;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangLengthArgImpl extends YangNamedElementImpl implements YangLengthArg {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangLengthBoundaryImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangLengthBoundaryImpl.java
@@ -1,9 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_MAX_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_MIN_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -12,6 +9,9 @@ import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangLengthBoundary;
 import tech.pantheon.yanginator.plugin.psi.YangNonNegativeIntegerValue;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_MAX_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_MIN_KEYWORD;
 
 public class YangLengthBoundaryImpl extends YangNamedElementImpl implements YangLengthBoundary {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangLengthPartImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangLengthPartImpl.java
@@ -1,19 +1,20 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_DOUBLE_DOT;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangLengthBoundary;
 import tech.pantheon.yanginator.plugin.psi.YangLengthPart;
 import tech.pantheon.yanginator.plugin.psi.YangOptsep;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_DOUBLE_DOT;
 
 public class YangLengthPartImpl extends YangNamedElementImpl implements YangLengthPart {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangLengthStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangLengthStmtImpl.java
@@ -1,16 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LENGTH_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangLengthArgStr;
@@ -20,6 +14,13 @@ import tech.pantheon.yanginator.plugin.psi.YangOptsep;
 import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LENGTH_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
 
 public class YangLengthStmtImpl extends YangStatementImpl implements YangLengthStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangLfImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangLfImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LINEFEED;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -11,6 +9,8 @@ import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangLf;
 import tech.pantheon.yanginator.plugin.psi.YangLineComment;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LINEFEED;
 
 public class YangLfImpl extends YangNamedElementImpl implements YangLf {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangLineCommentImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangLineCommentImpl.java
@@ -1,19 +1,20 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SINGLE_LINE_COMMENT_START;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangLineComment;
 import tech.pantheon.yanginator.plugin.psi.YangNewLineCharacters;
 import tech.pantheon.yanginator.plugin.psi.YangSingleLineCharacters;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SINGLE_LINE_COMMENT_START;
 
 public class YangLineCommentImpl extends YangNamedElementImpl implements YangLineComment {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangLinkageStmtsImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangLinkageStmtsImpl.java
@@ -4,11 +4,12 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangLinkageStmts;
 import tech.pantheon.yanginator.plugin.psi.YangLinkageStmtsBody;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangLinkageStmtsImpl extends YangNamedElementImpl implements YangLinkageStmts {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangListStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangListStmtImpl.java
@@ -1,15 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LIST_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangIdentifierArgQuoted;
 import tech.pantheon.yanginator.plugin.psi.YangListStmt;
@@ -18,6 +13,12 @@ import tech.pantheon.yanginator.plugin.psi.YangOptsep;
 import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LIST_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
 
 public class YangListStmtImpl extends YangStatementImpl implements YangListStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangLs32Impl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangLs32Impl.java
@@ -4,13 +4,14 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangH16;
 import tech.pantheon.yanginator.plugin.psi.YangIPv4Address;
 import tech.pantheon.yanginator.plugin.psi.YangLs32;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangLs32Impl extends YangNamedElementImpl implements YangLs32 {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangMandatoryArgImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangMandatoryArgImpl.java
@@ -1,9 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_FALSE_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_TRUE_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -11,6 +8,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangMandatoryArg;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_FALSE_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_TRUE_KEYWORD;
 
 public class YangMandatoryArgImpl extends YangNamedElementImpl implements YangMandatoryArg {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangMandatoryStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangMandatoryStmtImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_MANDATORY_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -12,6 +10,8 @@ import tech.pantheon.yanginator.plugin.psi.YangMandatoryStmt;
 import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtend;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_MANDATORY_KEYWORD;
 
 public class YangMandatoryStmtImpl extends YangStatementImpl implements YangMandatoryStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangMaxElementsStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangMaxElementsStmtImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_MAX_ELEMENTS_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -12,6 +10,8 @@ import tech.pantheon.yanginator.plugin.psi.YangMaxValueArgStr;
 import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtend;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_MAX_ELEMENTS_KEYWORD;
 
 public class YangMaxElementsStmtImpl extends YangStatementImpl implements YangMaxElementsStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangMaxValueArgImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangMaxValueArgImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_UNBOUNDED_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -11,6 +9,8 @@ import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangMaxValueArg;
 import tech.pantheon.yanginator.plugin.psi.YangPositiveIntegerValue;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_UNBOUNDED_KEYWORD;
 
 public class YangMaxValueArgImpl extends YangNamedElementImpl implements YangMaxValueArg {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangMetaStmtsImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangMetaStmtsImpl.java
@@ -4,11 +4,12 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangMetaStmts;
 import tech.pantheon.yanginator.plugin.psi.YangMetaStmtsBody;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangMetaStmtsImpl extends YangNamedElementImpl implements YangMetaStmts {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangMinElementsStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangMinElementsStmtImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_MIN_ELEMENTS_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -12,6 +10,8 @@ import tech.pantheon.yanginator.plugin.psi.YangMinValueArgStr;
 import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtend;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_MIN_ELEMENTS_KEYWORD;
 
 public class YangMinElementsStmtImpl extends YangStatementImpl implements YangMinElementsStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangModuleHeaderStmtsImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangModuleHeaderStmtsImpl.java
@@ -4,11 +4,12 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangModuleHeaderStmts;
 import tech.pantheon.yanginator.plugin.psi.YangModuleHeaderStmtsBody;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangModuleHeaderStmtsImpl extends YangNamedElementImpl implements YangModuleHeaderStmts {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangModuleStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangModuleStmtImpl.java
@@ -1,15 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_MODULE_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangBodyStmts;
@@ -23,6 +18,12 @@ import tech.pantheon.yanginator.plugin.psi.YangRevisionStmts;
 import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_MODULE_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
 
 public class YangModuleStmtImpl extends YangStatementImpl implements YangModuleStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangMustStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangMustStmtImpl.java
@@ -1,16 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_MUST_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangMustStmt;
@@ -20,6 +14,13 @@ import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangString;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_MUST_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
 
 public class YangMustStmtImpl extends YangStatementImpl implements YangMustStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangNamespaceStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangNamespaceStmtImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_NAMESPACE_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -13,6 +11,8 @@ import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtend;
 import tech.pantheon.yanginator.plugin.psi.YangUriStr;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_NAMESPACE_KEYWORD;
 
 public class YangNamespaceStmtImpl extends YangStatementImpl implements YangNamespaceStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangNewLineCharactersImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangNewLineCharactersImpl.java
@@ -1,9 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_CARRIAGE_RETURN;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LINEFEED;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -11,6 +8,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangNewLineCharacters;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_CARRIAGE_RETURN;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LINEFEED;
 
 public class YangNewLineCharactersImpl extends YangNamedElementImpl implements YangNewLineCharacters {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangNodeIdentifierImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangNodeIdentifierImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_COLON;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -12,6 +10,8 @@ import tech.pantheon.yanginator.plugin.psi.YangIdentifier;
 import tech.pantheon.yanginator.plugin.psi.YangNodeIdentifier;
 import tech.pantheon.yanginator.plugin.psi.YangPrefix;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_COLON;
 
 public class YangNodeIdentifierImpl extends YangNamedElementImpl implements YangNodeIdentifier {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangNodeIdentifierQuotedImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangNodeIdentifierQuotedImpl.java
@@ -1,13 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_COLON;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangIdentifierQuoted;
@@ -15,6 +12,10 @@ import tech.pantheon.yanginator.plugin.psi.YangNodeIdentifierQuoted;
 import tech.pantheon.yanginator.plugin.psi.YangPrefixQuoted;
 import tech.pantheon.yanginator.plugin.psi.YangStringSplitter;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_COLON;
 
 public class YangNodeIdentifierQuotedImpl extends YangNamedElementImpl implements YangNodeIdentifierQuoted {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangNonNegativeIntegerValueImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangNonNegativeIntegerValueImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_ZERO;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -11,6 +9,8 @@ import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangNonNegativeIntegerValue;
 import tech.pantheon.yanginator.plugin.psi.YangPositiveIntegerValue;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_ZERO;
 
 public class YangNonNegativeIntegerValueImpl extends YangNamedElementImpl implements YangNonNegativeIntegerValue {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangNonQuotedStringImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangNonQuotedStringImpl.java
@@ -4,12 +4,13 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangIdentifierLiteral;
 import tech.pantheon.yanginator.plugin.psi.YangNonQuotedString;
 import tech.pantheon.yanginator.plugin.psi.YangUnquotedStringBodyCharacters;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangNonQuotedStringImpl extends YangNamedElementImpl implements YangNonQuotedString {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangNonZeroDigitImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangNonZeroDigitImpl.java
@@ -1,14 +1,14 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_POSITIVE_NUMBER;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangNonZeroDigit;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_POSITIVE_NUMBER;
 
 public class YangNonZeroDigitImpl extends YangNamedElementImpl implements YangNonZeroDigit {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangNotificationStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangNotificationStmtImpl.java
@@ -1,16 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_NOTIFICATION_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangIdentifierArgQuoted;
@@ -20,6 +14,13 @@ import tech.pantheon.yanginator.plugin.psi.YangOptsep;
 import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_NOTIFICATION_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
 
 public class YangNotificationStmtImpl extends YangStatementImpl implements YangNotificationStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangOptsepImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangOptsepImpl.java
@@ -4,12 +4,13 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangLineBreak;
 import tech.pantheon.yanginator.plugin.psi.YangOptsep;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
 import tech.pantheon.yanginator.plugin.psi.YangWsp;
+
+import java.util.List;
 
 public class YangOptsepImpl extends YangNamedElementImpl implements YangOptsep {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangOrderedByArgImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangOrderedByArgImpl.java
@@ -1,9 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SYSTEM_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_USER_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -11,6 +8,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangOrderedByArg;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SYSTEM_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_USER_KEYWORD;
 
 public class YangOrderedByArgImpl extends YangNamedElementImpl implements YangOrderedByArg {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangOrderedByStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangOrderedByStmtImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_ORDERED_BY_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -12,6 +10,8 @@ import tech.pantheon.yanginator.plugin.psi.YangOrderedByStmt;
 import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtend;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_ORDERED_BY_KEYWORD;
 
 public class YangOrderedByStmtImpl extends YangStatementImpl implements YangOrderedByStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangOrganizationStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangOrganizationStmtImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_ORGANIZATION_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -13,6 +11,8 @@ import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtend;
 import tech.pantheon.yanginator.plugin.psi.YangString;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_ORGANIZATION_KEYWORD;
 
 public class YangOrganizationStmtImpl extends YangStatementImpl implements YangOrganizationStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangOutputStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangOutputStmtImpl.java
@@ -1,21 +1,22 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_OUTPUT_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangOptsep;
 import tech.pantheon.yanginator.plugin.psi.YangOutputStmt;
 import tech.pantheon.yanginator.plugin.psi.YangOutputStmtBody;
 import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_OUTPUT_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
 
 public class YangOutputStmtImpl extends YangStatementImpl implements YangOutputStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangPathAbemptyImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangPathAbemptyImpl.java
@@ -4,11 +4,12 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangPathAbempty;
 import tech.pantheon.yanginator.plugin.psi.YangSegment;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangPathAbemptyImpl extends YangNamedElementImpl implements YangPathAbempty {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangPathAbsoluteImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangPathAbsoluteImpl.java
@@ -4,13 +4,14 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangPathAbsolute;
 import tech.pantheon.yanginator.plugin.psi.YangSegment;
 import tech.pantheon.yanginator.plugin.psi.YangSegmentNz;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangPathAbsoluteImpl extends YangNamedElementImpl implements YangPathAbsolute {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangPathEqualityExprImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangPathEqualityExprImpl.java
@@ -1,13 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_EQUAL;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangNodeIdentifier;
 import tech.pantheon.yanginator.plugin.psi.YangPathEqualityExpr;
@@ -15,6 +12,10 @@ import tech.pantheon.yanginator.plugin.psi.YangPathKeyExpr;
 import tech.pantheon.yanginator.plugin.psi.YangStringSplitter;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
 import tech.pantheon.yanginator.plugin.psi.YangWsp;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_EQUAL;
 
 public class YangPathEqualityExprImpl extends YangNamedElementImpl implements YangPathEqualityExpr {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangPathKeyExprImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangPathKeyExprImpl.java
@@ -1,13 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_FORWARD_SLASH;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangCurrentFunctionInvocation;
 import tech.pantheon.yanginator.plugin.psi.YangPathKeyExpr;
@@ -15,6 +12,10 @@ import tech.pantheon.yanginator.plugin.psi.YangRelPathKeyexpr;
 import tech.pantheon.yanginator.plugin.psi.YangStringSplitter;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
 import tech.pantheon.yanginator.plugin.psi.YangWsp;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_FORWARD_SLASH;
 
 public class YangPathKeyExprImpl extends YangNamedElementImpl implements YangPathKeyExpr {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangPathPredicateImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangPathPredicateImpl.java
@@ -1,20 +1,21 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_CLOSED_BRACKET;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_OPEN_BRACKET;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangPathEqualityExpr;
 import tech.pantheon.yanginator.plugin.psi.YangPathPredicate;
 import tech.pantheon.yanginator.plugin.psi.YangStringSplitter;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
 import tech.pantheon.yanginator.plugin.psi.YangWsp;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_CLOSED_BRACKET;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_OPEN_BRACKET;
 
 public class YangPathPredicateImpl extends YangNamedElementImpl implements YangPathPredicate {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangPathRootlessImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangPathRootlessImpl.java
@@ -4,12 +4,13 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangPathRootless;
 import tech.pantheon.yanginator.plugin.psi.YangSegment;
 import tech.pantheon.yanginator.plugin.psi.YangSegmentNz;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangPathRootlessImpl extends YangNamedElementImpl implements YangPathRootless {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangPathStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangPathStmtImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_PATH_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -12,6 +10,8 @@ import tech.pantheon.yanginator.plugin.psi.YangPathStmt;
 import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtend;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_PATH_KEYWORD;
 
 public class YangPathStmtImpl extends YangStatementImpl implements YangPathStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangPatternStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangPatternStmtImpl.java
@@ -1,16 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_PATTERN_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangOptsep;
@@ -20,6 +14,13 @@ import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangString;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_PATTERN_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
 
 public class YangPatternStmtImpl extends YangStatementImpl implements YangPatternStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangPcharImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangPcharImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_COLON;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -14,6 +12,8 @@ import tech.pantheon.yanginator.plugin.psi.YangPctEncoded;
 import tech.pantheon.yanginator.plugin.psi.YangSubDelims;
 import tech.pantheon.yanginator.plugin.psi.YangUnreserved;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_COLON;
 
 public class YangPcharImpl extends YangNamedElementImpl implements YangPchar {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangPctEncodedImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangPctEncodedImpl.java
@@ -4,11 +4,12 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangHexdig;
 import tech.pantheon.yanginator.plugin.psi.YangPctEncoded;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangPctEncodedImpl extends YangNamedElementImpl implements YangPctEncoded {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangPortImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangPortImpl.java
@@ -4,11 +4,12 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangDigit;
 import tech.pantheon.yanginator.plugin.psi.YangPort;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangPortImpl extends YangNamedElementImpl implements YangPort {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangPositionStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangPositionStmtImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_POSITION_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -12,6 +10,8 @@ import tech.pantheon.yanginator.plugin.psi.YangPositionValueArgStr;
 import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtend;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_POSITION_KEYWORD;
 
 public class YangPositionStmtImpl extends YangStatementImpl implements YangPositionStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangPositiveIntegerValueImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangPositiveIntegerValueImpl.java
@@ -4,12 +4,13 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangDigit;
 import tech.pantheon.yanginator.plugin.psi.YangNonZeroDigit;
 import tech.pantheon.yanginator.plugin.psi.YangPositiveIntegerValue;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangPositiveIntegerValueImpl extends YangNamedElementImpl implements YangPositiveIntegerValue {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangPredicateExprImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangPredicateExprImpl.java
@@ -1,14 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_DOT;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_EQUAL;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangNodeIdentifier;
@@ -16,6 +12,11 @@ import tech.pantheon.yanginator.plugin.psi.YangNonQuotedString;
 import tech.pantheon.yanginator.plugin.psi.YangPredicateExpr;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
 import tech.pantheon.yanginator.plugin.psi.YangWsp;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_DOT;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_EQUAL;
 
 public class YangPredicateExprImpl extends YangNamedElementImpl implements YangPredicateExpr {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangPredicateImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangPredicateImpl.java
@@ -1,19 +1,20 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_OPEN_BRACKET;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangPos;
 import tech.pantheon.yanginator.plugin.psi.YangPredicate;
 import tech.pantheon.yanginator.plugin.psi.YangPredicateExpr;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
 import tech.pantheon.yanginator.plugin.psi.YangWsp;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_OPEN_BRACKET;
 
 public class YangPredicateImpl extends YangNamedElementImpl implements YangPredicate {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangPrefixStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangPrefixStmtImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_PREFIX_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -13,6 +11,8 @@ import tech.pantheon.yanginator.plugin.psi.YangPrefixStmt;
 import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtend;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_PREFIX_KEYWORD;
 
 public class YangPrefixStmtImpl extends YangStatementImpl implements YangPrefixStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangPresenceStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangPresenceStmtImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_PRESENCE_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -12,6 +10,8 @@ import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtend;
 import tech.pantheon.yanginator.plugin.psi.YangString;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_PRESENCE_KEYWORD;
 
 public class YangPresenceStmtImpl extends YangStatementImpl implements YangPresenceStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangQueryImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangQueryImpl.java
@@ -4,11 +4,12 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangPchar;
 import tech.pantheon.yanginator.plugin.psi.YangQuery;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangQueryImpl extends YangNamedElementImpl implements YangQuery {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangQuotedStringBodyCharactersImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangQuotedStringBodyCharactersImpl.java
@@ -1,10 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SINGLE_LINE_COMMENT_START;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_STRINGS_DOUBLE_QUOTE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_STRINGS_SINGLE_QUOTE;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -17,6 +13,10 @@ import tech.pantheon.yanginator.plugin.psi.YangQuotedStringBodyCharacters;
 import tech.pantheon.yanginator.plugin.psi.YangSp;
 import tech.pantheon.yanginator.plugin.psi.YangVchar;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SINGLE_LINE_COMMENT_START;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_STRINGS_DOUBLE_QUOTE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_STRINGS_SINGLE_QUOTE;
 
 public class YangQuotedStringBodyCharactersImpl extends YangNamedElementImpl implements YangQuotedStringBodyCharacters {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRangeArgImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRangeArgImpl.java
@@ -4,12 +4,13 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangOptsep;
 import tech.pantheon.yanginator.plugin.psi.YangRangeArg;
 import tech.pantheon.yanginator.plugin.psi.YangRangePart;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangRangeArgImpl extends YangNamedElementImpl implements YangRangeArg {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRangeBoundaryImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRangeBoundaryImpl.java
@@ -1,9 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_MAX_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_MIN_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -13,6 +10,9 @@ import tech.pantheon.yanginator.plugin.psi.YangDecimalValue;
 import tech.pantheon.yanginator.plugin.psi.YangIntegerValue;
 import tech.pantheon.yanginator.plugin.psi.YangRangeBoundary;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_MAX_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_MIN_KEYWORD;
 
 public class YangRangeBoundaryImpl extends YangNamedElementImpl implements YangRangeBoundary {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRangePartImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRangePartImpl.java
@@ -1,19 +1,20 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_DOUBLE_DOT;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangOptsep;
 import tech.pantheon.yanginator.plugin.psi.YangRangeBoundary;
 import tech.pantheon.yanginator.plugin.psi.YangRangePart;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_DOUBLE_DOT;
 
 public class YangRangePartImpl extends YangNamedElementImpl implements YangRangePart {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRangeStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRangeStmtImpl.java
@@ -1,16 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RANGE_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangOptsep;
@@ -20,6 +14,13 @@ import tech.pantheon.yanginator.plugin.psi.YangRangeStmtBody;
 import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RANGE_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
 
 public class YangRangeStmtImpl extends YangStatementImpl implements YangRangeStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangReferenceStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangReferenceStmtImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_REFERENCE_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -13,6 +11,8 @@ import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtend;
 import tech.pantheon.yanginator.plugin.psi.YangString;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_REFERENCE_KEYWORD;
 
 public class YangReferenceStmtImpl extends YangStatementImpl implements YangReferenceStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRefineAnyxmlStmtsImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRefineAnyxmlStmtsImpl.java
@@ -4,11 +4,12 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangRefineAnyxmlStmts;
 import tech.pantheon.yanginator.plugin.psi.YangRefineAnyxmlStmtsBody;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangRefineAnyxmlStmtsImpl extends YangNamedElementImpl implements YangRefineAnyxmlStmts {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRefineCaseStmtsImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRefineCaseStmtsImpl.java
@@ -4,11 +4,12 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangRefineCaseStmts;
 import tech.pantheon.yanginator.plugin.psi.YangRefineCaseStmtsBody;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangRefineCaseStmtsImpl extends YangNamedElementImpl implements YangRefineCaseStmts {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRefineChoiceStmtsImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRefineChoiceStmtsImpl.java
@@ -4,11 +4,12 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangRefineChoiceStmts;
 import tech.pantheon.yanginator.plugin.psi.YangRefineChoiceStmtsBody;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangRefineChoiceStmtsImpl extends YangNamedElementImpl implements YangRefineChoiceStmts {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRefineContainerStmtsImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRefineContainerStmtsImpl.java
@@ -4,11 +4,12 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangRefineContainerStmts;
 import tech.pantheon.yanginator.plugin.psi.YangRefineContainerStmtsBody;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangRefineContainerStmtsImpl extends YangNamedElementImpl implements YangRefineContainerStmts {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRefineLeafListStmtsImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRefineLeafListStmtsImpl.java
@@ -4,11 +4,12 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangRefineLeafListStmts;
 import tech.pantheon.yanginator.plugin.psi.YangRefineLeafListStmtsBody;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangRefineLeafListStmtsImpl extends YangNamedElementImpl implements YangRefineLeafListStmts {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRefineLeafStmtsImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRefineLeafStmtsImpl.java
@@ -4,11 +4,12 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangRefineLeafStmts;
 import tech.pantheon.yanginator.plugin.psi.YangRefineLeafStmtsBody;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangRefineLeafStmtsImpl extends YangNamedElementImpl implements YangRefineLeafStmts {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRefineListStmtsImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRefineListStmtsImpl.java
@@ -4,11 +4,12 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangRefineListStmts;
 import tech.pantheon.yanginator.plugin.psi.YangRefineListStmtsBody;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangRefineListStmtsImpl extends YangNamedElementImpl implements YangRefineListStmts {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRefineStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRefineStmtImpl.java
@@ -1,11 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_REFINE_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -24,6 +19,11 @@ import tech.pantheon.yanginator.plugin.psi.YangRefineStmt;
 import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_REFINE_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
 
 public class YangRefineStmtImpl extends YangStatementImpl implements YangRefineStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRegNameImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRegNameImpl.java
@@ -4,7 +4,6 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangIdentifierLiteral;
 import tech.pantheon.yanginator.plugin.psi.YangPctEncoded;
@@ -12,6 +11,8 @@ import tech.pantheon.yanginator.plugin.psi.YangRegName;
 import tech.pantheon.yanginator.plugin.psi.YangSubDelims;
 import tech.pantheon.yanginator.plugin.psi.YangUnreserved;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangRegNameImpl extends YangNamedElementImpl implements YangRegName {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRelPathKeyexprImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRelPathKeyexprImpl.java
@@ -4,12 +4,13 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangNodeIdentifier;
 import tech.pantheon.yanginator.plugin.psi.YangRelPathKeyexpr;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
 import tech.pantheon.yanginator.plugin.psi.YangWsp;
+
+import java.util.List;
 
 public class YangRelPathKeyexprImpl extends YangNamedElementImpl implements YangRelPathKeyexpr {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRelativePathImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRelativePathImpl.java
@@ -4,12 +4,13 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangDescendantPath;
 import tech.pantheon.yanginator.plugin.psi.YangRelativePath;
 import tech.pantheon.yanginator.plugin.psi.YangStringSplitter;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangRelativePathImpl extends YangNamedElementImpl implements YangRelativePath {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRequireInstanceArgImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRequireInstanceArgImpl.java
@@ -1,9 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_FALSE_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_TRUE_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -11,6 +8,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangRequireInstanceArg;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_FALSE_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_TRUE_KEYWORD;
 
 public class YangRequireInstanceArgImpl extends YangNamedElementImpl implements YangRequireInstanceArg {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRequireInstanceStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRequireInstanceStmtImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_REQUIRE_INSTANCE_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -12,6 +10,8 @@ import tech.pantheon.yanginator.plugin.psi.YangRequireInstanceStmt;
 import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtend;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_REQUIRE_INSTANCE_KEYWORD;
 
 public class YangRequireInstanceStmtImpl extends YangStatementImpl implements YangRequireInstanceStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRevisionDateStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRevisionDateStmtImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_REVISION_DATE_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -12,6 +10,8 @@ import tech.pantheon.yanginator.plugin.psi.YangRevisionDateStmt;
 import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtend;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_REVISION_DATE_KEYWORD;
 
 public class YangRevisionDateStmtImpl extends YangStatementImpl implements YangRevisionDateStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRevisionStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRevisionStmtImpl.java
@@ -1,16 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_REVISION_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangOptsep;
@@ -20,6 +14,13 @@ import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStatement;
 import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_REVISION_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
 
 public class YangRevisionStmtImpl extends YangStatementImpl implements YangRevisionStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRevisionStmtsImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRevisionStmtsImpl.java
@@ -4,12 +4,13 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangRevisionStmt;
 import tech.pantheon.yanginator.plugin.psi.YangRevisionStmts;
 import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangRevisionStmtsImpl extends YangNamedElementImpl implements YangRevisionStmts {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRpcStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangRpcStmtImpl.java
@@ -1,16 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RPC_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangIdentifierArgQuoted;
@@ -20,6 +14,13 @@ import tech.pantheon.yanginator.plugin.psi.YangRpcStmtBody;
 import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RPC_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
 
 public class YangRpcStmtImpl extends YangStatementImpl implements YangRpcStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangSchemeImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangSchemeImpl.java
@@ -4,12 +4,13 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangDigit;
 import tech.pantheon.yanginator.plugin.psi.YangIdentifierLiteral;
 import tech.pantheon.yanginator.plugin.psi.YangScheme;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangSchemeImpl extends YangNamedElementImpl implements YangScheme {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangSegmentImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangSegmentImpl.java
@@ -4,11 +4,12 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangPchar;
 import tech.pantheon.yanginator.plugin.psi.YangSegment;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangSegmentImpl extends YangNamedElementImpl implements YangSegment {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangSegmentNzImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangSegmentNzImpl.java
@@ -4,11 +4,12 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangPchar;
 import tech.pantheon.yanginator.plugin.psi.YangSegmentNz;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangSegmentNzImpl extends YangNamedElementImpl implements YangSegmentNz {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangSepImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangSepImpl.java
@@ -4,12 +4,13 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangLineBreak;
 import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
 import tech.pantheon.yanginator.plugin.psi.YangWsp;
+
+import java.util.List;
 
 public class YangSepImpl extends YangNamedElementImpl implements YangSep {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangSingleLineCharactersImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangSingleLineCharactersImpl.java
@@ -1,10 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_DOUBLE_QUOTE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SINGLE_LINE_COMMENT_START;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SINGLE_QUOTE;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -16,6 +12,10 @@ import tech.pantheon.yanginator.plugin.psi.YangSingleLineCharacters;
 import tech.pantheon.yanginator.plugin.psi.YangSp;
 import tech.pantheon.yanginator.plugin.psi.YangVchar;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_DOUBLE_QUOTE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SINGLE_LINE_COMMENT_START;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SINGLE_QUOTE;
 
 public class YangSingleLineCharactersImpl extends YangNamedElementImpl implements YangSingleLineCharacters {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangSingleQuoteStringSplitterImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangSingleQuoteStringSplitterImpl.java
@@ -4,11 +4,12 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangSingleQuoteStringSplitter;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangSingleQuoteStringSplitterImpl extends YangNamedElementImpl implements YangSingleQuoteStringSplitter {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangSingleQuotedStringBodyCharactersImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangSingleQuotedStringBodyCharactersImpl.java
@@ -1,10 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SINGLE_LINE_COMMENT_START;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_STRINGS_DOUBLE_QUOTE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_STRINGS_SINGLE_QUOTE;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -17,6 +13,10 @@ import tech.pantheon.yanginator.plugin.psi.YangSingleQuotedStringBodyCharacters;
 import tech.pantheon.yanginator.plugin.psi.YangSp;
 import tech.pantheon.yanginator.plugin.psi.YangVchar;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SINGLE_LINE_COMMENT_START;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_STRINGS_DOUBLE_QUOTE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_STRINGS_SINGLE_QUOTE;
 
 public class YangSingleQuotedStringBodyCharactersImpl extends YangNamedElementImpl implements YangSingleQuotedStringBodyCharacters {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangSpImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangSpImpl.java
@@ -1,14 +1,14 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SPACE;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangSp;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SPACE;
 
 public class YangSpImpl extends YangNamedElementImpl implements YangSp {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangSplittedCurrentKeywordImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangSplittedCurrentKeywordImpl.java
@@ -4,11 +4,12 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangSplittedCurrentKeyword;
 import tech.pantheon.yanginator.plugin.psi.YangStringSplitter;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangSplittedCurrentKeywordImpl extends YangNamedElementImpl implements YangSplittedCurrentKeyword {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangStatusArgImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangStatusArgImpl.java
@@ -1,10 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_CURRENT_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_DEPRECATED_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_OBSOLETE_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -12,6 +8,10 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangStatusArg;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_CURRENT_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_DEPRECATED_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_OBSOLETE_KEYWORD;
 
 public class YangStatusArgImpl extends YangNamedElementImpl implements YangStatusArg {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangStatusStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangStatusStmtImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_STATUS_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -12,6 +10,8 @@ import tech.pantheon.yanginator.plugin.psi.YangStatusArgStr;
 import tech.pantheon.yanginator.plugin.psi.YangStatusStmt;
 import tech.pantheon.yanginator.plugin.psi.YangStmtend;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_STATUS_KEYWORD;
 
 public class YangStatusStmtImpl extends YangStatementImpl implements YangStatusStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangStmtendImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangStmtendImpl.java
@@ -1,20 +1,21 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangStmtend;
 import tech.pantheon.yanginator.plugin.psi.YangUnknownStatement;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
 
 public class YangStmtendImpl extends YangNamedElementImpl implements YangStmtend {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangStmtsepImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangStmtsepImpl.java
@@ -4,13 +4,14 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangLineBreak;
 import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangUnknownStatement;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
 import tech.pantheon.yanginator.plugin.psi.YangWsp;
+
+import java.util.List;
 
 public class YangStmtsepImpl extends YangNamedElementImpl implements YangStmtsep {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangStringImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangStringImpl.java
@@ -4,7 +4,6 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangIdentifierLiteral;
@@ -15,6 +14,8 @@ import tech.pantheon.yanginator.plugin.psi.YangSingleQuotedStringBodyCharacters;
 import tech.pantheon.yanginator.plugin.psi.YangString;
 import tech.pantheon.yanginator.plugin.psi.YangStringSplitter;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangStringImpl extends YangNamedElementImpl implements YangString {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangStringRestrictionsImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangStringRestrictionsImpl.java
@@ -4,11 +4,12 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangStringRestrictions;
 import tech.pantheon.yanginator.plugin.psi.YangStringRestrictionsBody;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangStringRestrictionsImpl extends YangNamedElementImpl implements YangStringRestrictions {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangStringSplitterImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangStringSplitterImpl.java
@@ -4,11 +4,12 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStringSplitter;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangStringSplitterImpl extends YangNamedElementImpl implements YangStringSplitter {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangSubDelimsImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangSubDelimsImpl.java
@@ -1,12 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_EQUAL;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_PARENTHESIS;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_PARENTHESIS;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SINGLE_QUOTE;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -14,6 +8,12 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangSubDelims;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_EQUAL;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_PARENTHESIS;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_PARENTHESIS;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SINGLE_QUOTE;
 
 public class YangSubDelimsImpl extends YangNamedElementImpl implements YangSubDelims {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangSubmoduleHeaderStmtsImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangSubmoduleHeaderStmtsImpl.java
@@ -4,11 +4,12 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangSubmoduleHeaderStmts;
 import tech.pantheon.yanginator.plugin.psi.YangSubmoduleHeaderStmtsBody;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangSubmoduleHeaderStmtsImpl extends YangNamedElementImpl implements YangSubmoduleHeaderStmts {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangSubmoduleStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangSubmoduleStmtImpl.java
@@ -1,15 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SUBMODULE_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangBodyStmts;
@@ -23,6 +18,12 @@ import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangSubmoduleHeaderStmts;
 import tech.pantheon.yanginator.plugin.psi.YangSubmoduleStmt;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SUBMODULE_KEYWORD;
 
 public class YangSubmoduleStmtImpl extends YangStatementImpl implements YangSubmoduleStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangTokensImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangTokensImpl.java
@@ -1,14 +1,14 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_BLOCK_COMMENT;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangTokens;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_BLOCK_COMMENT;
 
 public class YangTokensImpl extends YangNamedElementImpl implements YangTokens {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangTypeStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangTypeStmtImpl.java
@@ -1,16 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_TYPE_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
-import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangIdentifierRefArgQuoted;
@@ -21,6 +14,11 @@ import tech.pantheon.yanginator.plugin.psi.YangTypeBodyStmts;
 import tech.pantheon.yanginator.plugin.psi.YangTypeStmt;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
 import tech.pantheon.yanginator.plugin.reference.YangGeneratedReferenceTypeImpl;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_TYPE_KEYWORD;
 
 public class YangTypeStmtImpl extends YangGeneratedReferenceTypeImpl implements YangTypeStmt {
 
@@ -63,9 +61,9 @@ public class YangTypeStmtImpl extends YangGeneratedReferenceTypeImpl implements 
   }
 
   @Override
-  @NotNull
-  public List<YangTypeBodyStmts> getTypeBodyStmtsList() {
-    return PsiTreeUtil.getChildrenOfTypeAsList(this, YangTypeBodyStmts.class);
+  @Nullable
+  public YangTypeBodyStmts getTypeBodyStmts() {
+    return findChildByClass(YangTypeBodyStmts.class);
   }
 
   @Override

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangTypedefStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangTypedefStmtImpl.java
@@ -1,15 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_TYPEDEF_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangIdentifierArgQuoted;
 import tech.pantheon.yanginator.plugin.psi.YangOptsep;
@@ -19,6 +14,12 @@ import tech.pantheon.yanginator.plugin.psi.YangTypedefStmt;
 import tech.pantheon.yanginator.plugin.psi.YangTypedefStmtBody;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
 import tech.pantheon.yanginator.plugin.reference.YangGeneratedReferenceTypeImpl;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_TYPEDEF_KEYWORD;
 
 public class YangTypedefStmtImpl extends YangGeneratedReferenceTypeImpl implements YangTypedefStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangUnionSpecificationImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangUnionSpecificationImpl.java
@@ -4,12 +4,13 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangStmtsep;
 import tech.pantheon.yanginator.plugin.psi.YangTypeStmt;
 import tech.pantheon.yanginator.plugin.psi.YangUnionSpecification;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangUnionSpecificationImpl extends YangNamedElementImpl implements YangUnionSpecification {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangUniqueArgImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangUniqueArgImpl.java
@@ -4,12 +4,13 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangDescendantSchemaNodeid;
 import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangUniqueArg;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangUniqueArgImpl extends YangNamedElementImpl implements YangUniqueArg {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangUniqueStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangUniqueStmtImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_UNIQUE_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -12,6 +10,8 @@ import tech.pantheon.yanginator.plugin.psi.YangStmtend;
 import tech.pantheon.yanginator.plugin.psi.YangUniqueArgStr;
 import tech.pantheon.yanginator.plugin.psi.YangUniqueStmt;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_UNIQUE_KEYWORD;
 
 public class YangUniqueStmtImpl extends YangStatementImpl implements YangUniqueStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangUnitsStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangUnitsStmtImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_UNITS_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -13,6 +11,8 @@ import tech.pantheon.yanginator.plugin.psi.YangStmtend;
 import tech.pantheon.yanginator.plugin.psi.YangString;
 import tech.pantheon.yanginator.plugin.psi.YangUnitsStmt;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_UNITS_KEYWORD;
 
 public class YangUnitsStmtImpl extends YangStatementImpl implements YangUnitsStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangUnknownStatement2Impl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangUnknownStatement2Impl.java
@@ -1,16 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_COLON;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangIdentifier;
@@ -20,6 +14,13 @@ import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangString;
 import tech.pantheon.yanginator.plugin.psi.YangUnknownStatement2;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_COLON;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
 
 public class YangUnknownStatement2Impl extends YangNamedElementImpl implements YangUnknownStatement2 {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangUnknownStatementImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangUnknownStatementImpl.java
@@ -1,16 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_COLON;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangIdentifier;
@@ -21,6 +15,13 @@ import tech.pantheon.yanginator.plugin.psi.YangString;
 import tech.pantheon.yanginator.plugin.psi.YangUnknownStatement;
 import tech.pantheon.yanginator.plugin.psi.YangUnknownStatement2;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_COLON;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
 
 public class YangUnknownStatementImpl extends YangNamedElementImpl implements YangUnknownStatement {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangUnquotedStringBodyCharactersImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangUnquotedStringBodyCharactersImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SINGLE_LINE_COMMENT_START;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -12,6 +10,8 @@ import tech.pantheon.yanginator.plugin.psi.YangIdentifierLiteral;
 import tech.pantheon.yanginator.plugin.psi.YangUnquotedStringBodyCharacters;
 import tech.pantheon.yanginator.plugin.psi.YangUnquotedVchar;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SINGLE_LINE_COMMENT_START;
 
 public class YangUnquotedStringBodyCharactersImpl extends YangNamedElementImpl implements YangUnquotedStringBodyCharacters {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangUnquotedVcharImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangUnquotedVcharImpl.java
@@ -1,6 +1,15 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiElementVisitor;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import tech.pantheon.yanginator.plugin.psi.YangDigit;
+import tech.pantheon.yanginator.plugin.psi.YangUnquotedVchar;
+import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
 import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_ALPHA;
 import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_ASTERISK;
 import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_BACK_SLASH;
@@ -21,15 +30,6 @@ import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
 import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_PARENTHESIS;
 import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SINGLE_LINE_COMMENT_START;
 import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_UNDERSCORE;
-
-import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
-import com.intellij.psi.PsiElementVisitor;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import tech.pantheon.yanginator.plugin.psi.YangDigit;
-import tech.pantheon.yanginator.plugin.psi.YangUnquotedVchar;
-import tech.pantheon.yanginator.plugin.psi.YangVisitor;
 
 public class YangUnquotedVcharImpl extends YangNamedElementImpl implements YangUnquotedVchar {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangUnreservedImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangUnreservedImpl.java
@@ -1,11 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_ALPHA;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_DASH;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_DOT;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_UNDERSCORE;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -14,6 +9,11 @@ import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangDigit;
 import tech.pantheon.yanginator.plugin.psi.YangUnreserved;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_ALPHA;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_DASH;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_DOT;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_UNDERSCORE;
 
 public class YangUnreservedImpl extends YangNamedElementImpl implements YangUnreserved {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangUriImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangUriImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_COLON;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -14,6 +12,8 @@ import tech.pantheon.yanginator.plugin.psi.YangQuery;
 import tech.pantheon.yanginator.plugin.psi.YangScheme;
 import tech.pantheon.yanginator.plugin.psi.YangUri;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_COLON;
 
 public class YangUriImpl extends YangNamedElementImpl implements YangUri {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangUserinfoImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangUserinfoImpl.java
@@ -4,13 +4,14 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangPctEncoded;
 import tech.pantheon.yanginator.plugin.psi.YangSubDelims;
 import tech.pantheon.yanginator.plugin.psi.YangUnreserved;
 import tech.pantheon.yanginator.plugin.psi.YangUserinfo;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
 
 public class YangUserinfoImpl extends YangNamedElementImpl implements YangUserinfo {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangUsesAugmentStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangUsesAugmentStmtImpl.java
@@ -1,15 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_AUGMENT_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangOptsep;
 import tech.pantheon.yanginator.plugin.psi.YangSep;
@@ -18,6 +13,12 @@ import tech.pantheon.yanginator.plugin.psi.YangUsesAugmentArgStr;
 import tech.pantheon.yanginator.plugin.psi.YangUsesAugmentStmt;
 import tech.pantheon.yanginator.plugin.psi.YangUsesAugmentStmtBody;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_AUGMENT_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
 
 public class YangUsesAugmentStmtImpl extends YangStatementImpl implements YangUsesAugmentStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangUsesStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangUsesStmtImpl.java
@@ -1,16 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_USES_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangIdentifierRefArgQuoted;
@@ -21,6 +15,13 @@ import tech.pantheon.yanginator.plugin.psi.YangUsesStmt;
 import tech.pantheon.yanginator.plugin.psi.YangUsesStmtBody;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
 import tech.pantheon.yanginator.plugin.reference.YangGeneratedReferenceTypeImpl;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_USES_KEYWORD;
 
 public class YangUsesStmtImpl extends YangGeneratedReferenceTypeImpl implements YangUsesStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangValueStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangValueStmtImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_VALUE_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -14,6 +12,8 @@ import tech.pantheon.yanginator.plugin.psi.YangSep;
 import tech.pantheon.yanginator.plugin.psi.YangStmtend;
 import tech.pantheon.yanginator.plugin.psi.YangValueStmt;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_VALUE_KEYWORD;
 
 public class YangValueStmtImpl extends YangStatementImpl implements YangValueStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangVcharImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangVcharImpl.java
@@ -1,6 +1,15 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiElementVisitor;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import tech.pantheon.yanginator.plugin.psi.YangDigit;
+import tech.pantheon.yanginator.plugin.psi.YangVchar;
+import tech.pantheon.yanginator.plugin.psi.YangVisitor;
+
 import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_ALPHA;
 import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_ASTERISK;
 import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_BACK_SLASH;
@@ -22,15 +31,6 @@ import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_PARENTHES
 import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
 import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SINGLE_LINE_COMMENT_START;
 import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_UNDERSCORE;
-
-import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
-import com.intellij.psi.PsiElementVisitor;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import tech.pantheon.yanginator.plugin.psi.YangDigit;
-import tech.pantheon.yanginator.plugin.psi.YangVchar;
-import tech.pantheon.yanginator.plugin.psi.YangVisitor;
 
 public class YangVcharImpl extends YangNamedElementImpl implements YangVchar {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangWhenStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangWhenStmtImpl.java
@@ -1,16 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_WHEN_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangOptsep;
@@ -20,6 +14,13 @@ import tech.pantheon.yanginator.plugin.psi.YangString;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
 import tech.pantheon.yanginator.plugin.psi.YangWhenStmt;
 import tech.pantheon.yanginator.plugin.psi.YangWhenStmtBody;
+
+import java.util.List;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_LEFT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_RIGHT_BRACE;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_SEMICOLON;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_WHEN_KEYWORD;
 
 public class YangWhenStmtImpl extends YangStatementImpl implements YangWhenStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangYangVersionArgImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangYangVersionArgImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_DOT;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -10,6 +8,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
 import tech.pantheon.yanginator.plugin.psi.YangYangVersionArg;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_DOT;
 
 public class YangYangVersionArgImpl extends YangNamedElementImpl implements YangYangVersionArg {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangYangVersionStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangYangVersionStmtImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_YANG_VERSION_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -13,6 +11,8 @@ import tech.pantheon.yanginator.plugin.psi.YangStmtend;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
 import tech.pantheon.yanginator.plugin.psi.YangYangVersionArgStr;
 import tech.pantheon.yanginator.plugin.psi.YangYangVersionStmt;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_YANG_VERSION_KEYWORD;
 
 public class YangYangVersionStmtImpl extends YangStatementImpl implements YangYangVersionStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangYinElementArgImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangYinElementArgImpl.java
@@ -1,9 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_FALSE_KEYWORD;
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_TRUE_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -11,6 +8,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
 import tech.pantheon.yanginator.plugin.psi.YangYinElementArg;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_FALSE_KEYWORD;
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_TRUE_KEYWORD;
 
 public class YangYinElementArgImpl extends YangNamedElementImpl implements YangYinElementArg {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangYinElementStmtImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangYinElementStmtImpl.java
@@ -1,8 +1,6 @@
 // This is a generated file. Not intended for manual editing.
 package tech.pantheon.yanginator.plugin.psi.impl;
 
-import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_YIN_ELEMENT_KEYWORD;
-
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
@@ -12,6 +10,8 @@ import tech.pantheon.yanginator.plugin.psi.YangStmtend;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
 import tech.pantheon.yanginator.plugin.psi.YangYinElementArgStr;
 import tech.pantheon.yanginator.plugin.psi.YangYinElementStmt;
+
+import static tech.pantheon.yanginator.plugin.psi.YangTypes.YANG_YIN_ELEMENT_KEYWORD;
 
 public class YangYinElementStmtImpl extends YangStatementImpl implements YangYinElementStmt {
 

--- a/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangZeroIntegerValueImpl.java
+++ b/intelij-plugin/src/main/gen/tech/pantheon/yanginator/plugin/psi/impl/YangZeroIntegerValueImpl.java
@@ -4,11 +4,12 @@ package tech.pantheon.yanginator.plugin.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import tech.pantheon.yanginator.plugin.psi.YangDigit;
 import tech.pantheon.yanginator.plugin.psi.YangVisitor;
 import tech.pantheon.yanginator.plugin.psi.YangZeroIntegerValue;
+
+import java.util.List;
 
 public class YangZeroIntegerValueImpl extends YangNamedElementImpl implements YangZeroIntegerValue {
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/YangGrammar.bnf
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/YangGrammar.bnf
@@ -249,7 +249,7 @@ typedef-stmt-body ::= (type-stmt stmtsep) |
 type-stmt ::= TYPE_KEYWORD sep identifier-ref-arg-quoted optsep
  ( SEMICOLON |
  ( LEFT_BRACE stmtsep
- type-body-stmts // + is not corresponding with rfc6020 (added additionally)
+ type-body-stmts
  RIGHT_BRACE ) )
  {
     implements="tech.pantheon.yanginator.plugin.reference.YangGeneratedReferenceType"
@@ -264,7 +264,7 @@ type-body-stmts ::= numerical-restrictions |
  instance-identifier-specification |
  bits-specification |
  union-specification |
- string-restrictions
+ string-restrictions     //order different than rfc6020 because string-restrictions can be empty so it have to be matched last.
 
 numerical-restrictions ::= range-stmt stmtsep
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/YangGrammar.bnf
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/YangGrammar.bnf
@@ -249,7 +249,7 @@ typedef-stmt-body ::= (type-stmt stmtsep) |
 type-stmt ::= TYPE_KEYWORD sep identifier-ref-arg-quoted optsep
  ( SEMICOLON |
  ( LEFT_BRACE stmtsep
- type-body-stmts + // + is not corresponding with rfc6020 (added additionally)
+ type-body-stmts // + is not corresponding with rfc6020 (added additionally)
  RIGHT_BRACE ) )
  {
     implements="tech.pantheon.yanginator.plugin.reference.YangGeneratedReferenceType"
@@ -258,13 +258,13 @@ type-stmt ::= TYPE_KEYWORD sep identifier-ref-arg-quoted optsep
 
 type-body-stmts ::= numerical-restrictions |
  decimal64-specification |
- string-restrictions |
  enum-specification |
  leafref-specification |
  identityref-specification |
  instance-identifier-specification |
  bits-specification |
- union-specification
+ union-specification |
+ string-restrictions
 
 numerical-restrictions ::= range-stmt stmtsep
 
@@ -293,7 +293,7 @@ fraction-digits-arg ::= ( "1" ( ZERO | "1" | "2" | "3" | "4" |
 string-restrictions-body ::= ( length-stmt stmtsep ) | // ?
  ( pattern-stmt stmtsep ) // *
 
- string-restrictions ::= string-restrictions-body +
+ string-restrictions ::= string-restrictions-body *
 
 length-stmt-body ::= ( error-message-stmt stmtsep ) | // ?
  ( error-app-tag-stmt stmtsep ) | // ?

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/YangLanguage.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/YangLanguage.java
@@ -16,7 +16,7 @@ public class YangLanguage extends Language {
     public static final YangLanguage INSTANCE = new YangLanguage();
 
     private YangLanguage() {
-        super("Yang");
+        super("yang-pantheon");
     }
 
 }

--- a/intelij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/intelij-plugin/src/main/resources/META-INF/plugin.xml
@@ -8,7 +8,7 @@
   ~  */
   -->
 
-<idea-plugin>
+<idea-plugin require-restart="true">
     <id>tech.pantheon.yanginator</id>
     <name>YANGinator</name>
     <category>Custom Languages</category>
@@ -21,34 +21,34 @@
     <depends>com.intellij.modules.java</depends>
 
     <extensions defaultExtensionNs="com.intellij">
-        <lang.commenter language="Yang"
+        <lang.commenter language="yang-pantheon"
                         implementationClass="tech.pantheon.yanginator.plugin.YangCommenter"/>
         <fileType name="Yang file" implementationClass="tech.pantheon.yanginator.plugin.YangFileType"
-                  fieldName="INSTANCE" language="Yang" extensions="yang"/>
+                  fieldName="INSTANCE" language="yang-pantheon" extensions="yang"/>
         <lang.parserDefinition
-                language="Yang"
+                language="yang-pantheon"
                 implementationClass="tech.pantheon.yanginator.plugin.YangParserDefinition"/>
-        <lang.foldingBuilder language="Yang"
+        <lang.foldingBuilder language="yang-pantheon"
                              implementationClass=
                                      "tech.pantheon.yanginator.plugin.foldingManager.YangCurlyBraceFoldingManager"/>
-        <lang.foldingBuilder language="Yang"
+        <lang.foldingBuilder language="yang-pantheon"
                              implementationClass=
                                      "tech.pantheon.yanginator.plugin.foldingManager.YangDescriptionFoldingManager"/>
-        <lang.foldingBuilder language="Yang"
+        <lang.foldingBuilder language="yang-pantheon"
                              implementationClass=
                                      "tech.pantheon.yanginator.plugin.foldingManager.YangCommentFoldingManager"/>
         <lang.syntaxHighlighterFactory
-                language="Yang"
+                language="yang-pantheon"
                 implementationClass="tech.pantheon.yanginator.plugin.editor.YangSyntaxHighlighterFactory"/>
         <colorSettingsPage implementation="tech.pantheon.yanginator.plugin.editor.YangColorSettingsPage"/>
-        <lang.commenter language="Yang"
+        <lang.commenter language="yang-pantheon"
                         implementationClass="tech.pantheon.yanginator.plugin.YangCommenter"/>
-        <lang.braceMatcher language="Yang" implementationClass="tech.pantheon.yanginator.plugin.editor.YangPairedCurlyBraceMatcher"/>
+        <lang.braceMatcher language="yang-pantheon" implementationClass="tech.pantheon.yanginator.plugin.editor.YangPairedCurlyBraceMatcher"/>
 
-        <completion.contributor language="Yang" implementationClass="tech.pantheon.yanginator.plugin.completion.YangCompletionContributor"/>
-        <lang.foldingBuilder language="Yang"
+        <completion.contributor language="yang-pantheon" implementationClass="tech.pantheon.yanginator.plugin.completion.YangCompletionContributor"/>
+        <lang.foldingBuilder language="yang-pantheon"
                              implementationClass="tech.pantheon.yanginator.plugin.completion.YangCompletionContributorBuilder"/>
-        <psi.referenceContributor language="Yang" implementation="tech.pantheon.yanginator.plugin.reference.YangReferenceContributor"/>
+        <psi.referenceContributor language="yang-pantheon" implementation="tech.pantheon.yanginator.plugin.reference.YangReferenceContributor"/>
 
         <psi.treeChangeListener implementation="tech.pantheon.yanginator.plugin.completion.YangPsiTreeChangeListener"/>
         <breadcrumbsInfoProvider implementation="tech.pantheon.yanginator.plugin.breadcrumbs.YangBreadcrumbsProvider"/>


### PR DESCRIPTION
Changing name of the language to avoid conflict with other plugins.

resolves #23 