### PR TITLE
changing name of the language

### DIFF
--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/YangLanguage.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/YangLanguage.java
@@ -16,7 +16,7 @@ public class YangLanguage extends Language {
     public static final YangLanguage INSTANCE = new YangLanguage();
 
     private YangLanguage() {
-        super("Yang");
+        super("yang-pantheon");
     }
 
 }

--- a/intelij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/intelij-plugin/src/main/resources/META-INF/plugin.xml
@@ -21,34 +21,34 @@
     <depends>com.intellij.modules.java</depends>
 
     <extensions defaultExtensionNs="com.intellij">
-        <lang.commenter language="Yang"
+        <lang.commenter language="yang-pantheon"
                         implementationClass="tech.pantheon.yanginator.plugin.YangCommenter"/>
         <fileType name="Yang file" implementationClass="tech.pantheon.yanginator.plugin.YangFileType"
-                  fieldName="INSTANCE" language="Yang" extensions="yang"/>
+                  fieldName="INSTANCE" language="yang-pantheon" extensions="yang"/>
         <lang.parserDefinition
-                language="Yang"
+                language="yang-pantheon"
                 implementationClass="tech.pantheon.yanginator.plugin.YangParserDefinition"/>
-        <lang.foldingBuilder language="Yang"
+        <lang.foldingBuilder language="yang-pantheon"
                              implementationClass=
                                      "tech.pantheon.yanginator.plugin.foldingManager.YangCurlyBraceFoldingManager"/>
-        <lang.foldingBuilder language="Yang"
+        <lang.foldingBuilder language="yang-pantheon"
                              implementationClass=
                                      "tech.pantheon.yanginator.plugin.foldingManager.YangDescriptionFoldingManager"/>
-        <lang.foldingBuilder language="Yang"
+        <lang.foldingBuilder language="yang-pantheon"
                              implementationClass=
                                      "tech.pantheon.yanginator.plugin.foldingManager.YangCommentFoldingManager"/>
         <lang.syntaxHighlighterFactory
-                language="Yang"
+                language="yang-pantheon"
                 implementationClass="tech.pantheon.yanginator.plugin.editor.YangSyntaxHighlighterFactory"/>
         <colorSettingsPage implementation="tech.pantheon.yanginator.plugin.editor.YangColorSettingsPage"/>
-        <lang.commenter language="Yang"
+        <lang.commenter language="yang-pantheon"
                         implementationClass="tech.pantheon.yanginator.plugin.YangCommenter"/>
-        <lang.braceMatcher language="Yang" implementationClass="tech.pantheon.yanginator.plugin.editor.YangPairedCurlyBraceMatcher"/>
+        <lang.braceMatcher language="yang-pantheon" implementationClass="tech.pantheon.yanginator.plugin.editor.YangPairedCurlyBraceMatcher"/>
 
-        <completion.contributor language="Yang" implementationClass="tech.pantheon.yanginator.plugin.completion.YangCompletionContributor"/>
-        <lang.foldingBuilder language="Yang"
+        <completion.contributor language="yang-pantheon" implementationClass="tech.pantheon.yanginator.plugin.completion.YangCompletionContributor"/>
+        <lang.foldingBuilder language="yang-pantheon"
                              implementationClass="tech.pantheon.yanginator.plugin.completion.YangCompletionContributorBuilder"/>
-        <psi.referenceContributor language="Yang" implementation="tech.pantheon.yanginator.plugin.reference.YangReferenceContributor"/>
+        <psi.referenceContributor language="yang-pantheon" implementation="tech.pantheon.yanginator.plugin.reference.YangReferenceContributor"/>
 
         <psi.treeChangeListener implementation="tech.pantheon.yanginator.plugin.completion.YangPsiTreeChangeListener"/>
         <breadcrumbsInfoProvider implementation="tech.pantheon.yanginator.plugin.breadcrumbs.YangBreadcrumbsProvider"/>


### PR DESCRIPTION
Changing name of the language to avoid conflict with other plugins.

resolves #23

Signed-off-by: Samuel Schneider <samuel.schneider@pantheon.tech>