### PR TITLE
Add automatic copyright check

### DIFF
--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,0 +1,84 @@
+# Required copyright formats:
+
+## Java:
+
+```/*
+*
+*   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+*
+*   This program and the accompanying materials are made available under the
+*   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+*   and is available at http://www.eclipse.org/legal/epl-v10.html
+*
+*/
+```
+
+or:
+
+```
+/*
+*
+*   Copyright (c) 2021-2022 PANTHEON.tech, s.r.o. All rights reserved.
+*
+*   This program and the accompanying materials are made available under the
+*   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+*   and is available at http://www.eclipse.org/legal/epl-v10.html
+*
+*/
+```
+
+or:
+
+```
+/*
+*
+*   Copyright (c) 2021,2022,2023,2024,2025 PANTHEON.tech, s.r.o. All rights reserved.
+*
+*   This program and the accompanying materials are made available under the
+*   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+*   and is available at http://www.eclipse.org/legal/epl-v10.html
+*
+*/
+```
+
+## XML:
+
+```
+<!--
+ ~
+ ~   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ ~
+ ~   This program and the accompanying materials are made available under the
+ ~   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ ~   and is available at http://www.eclipse.org/legal/epl-v10.html
+ ~
+ -->
+```
+
+or
+
+```
+<!--
+ ~
+ ~   Copyright (c) 2021-2022 PANTHEON.tech, s.r.o. All rights reserved.
+ ~
+ ~   This program and the accompanying materials are made available under the
+ ~   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ ~   and is available at http://www.eclipse.org/legal/epl-v10.html
+ ~
+ -->
+```
+
+or
+
+```
+<!--
+ ~
+ ~   Copyright (c) 2021,2022,2023 PANTHEON.tech, s.r.o. All rights reserved.
+ ~
+ ~   This program and the accompanying materials are made available under the
+ ~   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ ~   and is available at http://www.eclipse.org/legal/epl-v10.html
+ ~
+ -->
+```

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,21 @@
+plugins {
+    id 'java-library'
+    id 'checkstyle'
+}
+
+checkstyle {
+    configFile = rootProject.file('config/checkstyle/checkstyle.xml')
+}
+
+checkstyleMain {
+    //source has to be pointed at src/main/java, thats why it is a List
+    source = List.of('intelij-plugin/src/main/java', 'rfc-parser/src/main/java', 'intelij-plugin/src/main/resources')
+}
+
+checkstyleTest {
+    source = List.of('intelij-plugin/src/test/java', "rfc-parser/src/test")
+}
+
 group 'tech.pantheon.YANGinator'
 version '1.6-SNAPSHOT'
 
@@ -10,6 +28,7 @@ allprojects {
     repositories {
         mavenCentral()
     }
+
 }
 
 subprojects {
@@ -43,4 +62,5 @@ task createNextSnapshotVersion {
         String newBuildFile = buildFile.getText().replaceFirst("version '$version'", "version '" + snapshotVersion + "'")
         buildFile.setText(newBuildFile)
     }
+
 }

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+    <module name="RegexpHeader">
+        <property name="header" value="^/\*\n \*\n \ *
+        Copyright (\([Cc]\) )?(([0-9]{4},))|([0-9]{4}-[0-9]{4})|([0-9]{4}) PANTHEON.tech, s.r.o. All rights reserved.\n \*\n \ * This program and the accompanying materials are made available under the\n \ * terms of the Eclipse Public License v1.0 which accompanies this distribution,\n \ * and is available at http://www.eclipse.org/legal/epl-v10.html\n \*\n \*\/"/>
+        <property name="fileExtensions" value="java"/>
+        <property name="severity" value="error"/>
+        <message key="header.mismatch"
+                 value="Copyright header of .java has incorrect format or is missing. Expected:{0}"/>
+    </module>
+    <module name="RegexpHeader">
+        <property name="header" value="^\&lt;\!\-\-\n ~\n ~
+        Copyright (\([Cc]\) )?(([0-9]{4},))|([0-9]{4}-[0-9]{4})|([0-9]{4}) PANTHEON.tech, s.r.o. All rights reserved.\n ~\n ~   This program and the accompanying materials are made available under the\n ~   terms of the Eclipse Public License v1.0 which accompanies this distribution,\n ~   and is available at http://www.eclipse.org/legal/epl-v10.html\n ~\n \-\-\>"/>
+        <property name="fileExtensions" value="xml"/>
+        <property name="severity" value="error"/>
+        <message key="header.mismatch"
+                 value="Copyright header of .xml has incorrect format or is missing. Expected:{0}"/>
+    </module>
+</module>

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/YangAnnotator.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/YangAnnotator.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/check/ElementCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/check/ElementCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/check/ElementCheckUtils.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/check/ElementCheckUtils.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/check/MaxOneElementCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/check/MaxOneElementCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/check/MinOneElementCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/check/MinOneElementCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/AbstractYangStmtCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/AbstractYangStmtCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangAnyxmlStmtCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangAnyxmlStmtCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangAugmentStmtCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangAugmentStmtCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangBitStmtCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangBitStmtCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangCaseStmtCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangCaseStmtCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangChoiceStmtCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangChoiceStmtCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangContainerStmtCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangContainerStmtCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangDeviationStmtCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangDeviationStmtCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangEnumStmtChange.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangEnumStmtChange.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangExtensionStmtCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangExtensionStmtCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangFeatureStmtCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangFeatureStmtCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangGroupingStmtCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangGroupingStmtCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangIdentityStmtCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangIdentityStmtCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangInputStmtCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangInputStmtCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangLeafListStmtCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangLeafListStmtCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangLeafStmtCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangLeafStmtCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangLeafrefSpecificationCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangLeafrefSpecificationCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangLengthStmtCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangLengthStmtCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangListStmtCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangListStmtCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangMetaStmtCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangMetaStmtCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangModuleHeaderStmtCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangModuleHeaderStmtCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangModuleStmtCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangModuleStmtCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangMustStmtChange.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangMustStmtChange.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangNotificationStmtCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangNotificationStmtCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangOutputStmtCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangOutputStmtCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangPatternStmtCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangPatternStmtCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangRangeStmtChange.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangRangeStmtChange.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangRefineAnyxmlStmtsCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangRefineAnyxmlStmtsCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangRefineCaseStmtsCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangRefineCaseStmtsCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangRefineChoiceStmtsCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangRefineChoiceStmtsCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangRefineContainerStmtsCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangRefineContainerStmtsCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangRefineLeafListStmtsCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangRefineLeafListStmtsCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangRefineLeafStmtsCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangRefineLeafStmtsCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangRefineListStmtsCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangRefineListStmtsCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangRpcStmtCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangRpcStmtCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangStringRestrictionsCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangStringRestrictionsCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangSubmoduleHeaderStmtsCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangSubmoduleHeaderStmtsCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangSubmoduleStmtCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangSubmoduleStmtCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangTypedefStmtCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangTypedefStmtCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangUsesAugmentStmtCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangUsesAugmentStmtCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangUsesStmtCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangUsesStmtCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangWhenStmtCheck.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/annotator/element/YangWhenStmtCheck.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/breadcrumbs/YangBreadcrumbsPresentationProvider.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/breadcrumbs/YangBreadcrumbsPresentationProvider.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/breadcrumbs/YangBreadcrumbsProvider.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/breadcrumbs/YangBreadcrumbsProvider.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/breadcrumbs/YangCrumbPresentation.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/breadcrumbs/YangCrumbPresentation.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/external/ExternalRules.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/external/ExternalRules.java
@@ -1,3 +1,13 @@
+/*
+ *
+ *   Copyright (c) 2021-2022 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ */
+
 package tech.pantheon.yanginator.plugin.external;
 
 import static com.intellij.lang.parser.GeneratedParserUtilBase.enter_section_;

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/formatter/YangBlock.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/formatter/YangBlock.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/formatter/YangFormatterUtils.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/formatter/YangFormatterUtils.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/formatter/YangFormattingModelBuilder.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/formatter/YangFormattingModelBuilder.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/formatter/settings/YangCodeStyleMainPanel.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/formatter/settings/YangCodeStyleMainPanel.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/formatter/settings/YangCodeStyleSettings.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/formatter/settings/YangCodeStyleSettings.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/formatter/settings/YangCodeStyleSettingsProvider.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/formatter/settings/YangCodeStyleSettingsProvider.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/formatter/settings/YangLanguageCodeStyleSettingsProvider.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/formatter/settings/YangLanguageCodeStyleSettingsProvider.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v1.0 which accompanies this distribution,
- * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ *
+ *   This program and the accompanying materials are made available under the
+ *   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ *   and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  */
 

--- a/intelij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/intelij-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,12 +1,12 @@
 <!--
-  ~ /*
-  ~   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
-  ~
-  ~   This program and the accompanying materials are made available under the
-  ~   terms of the Eclipse Public License v1.0 which accompanies this distribution,
-  ~   and is available at http://www.eclipse.org/legal/epl-v10.html
-  ~  */
-  -->
+ ~
+ ~   Copyright (c) 2021 PANTHEON.tech, s.r.o. All rights reserved.
+ ~
+ ~   This program and the accompanying materials are made available under the
+ ~   terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ ~   and is available at http://www.eclipse.org/legal/epl-v10.html
+ ~
+ -->
 
 <idea-plugin url="https://github.com/PANTHEONtech/YANGinator">
     <id>tech.pantheon.yanginator</id>


### PR DESCRIPTION
- replace different copyright headers
- gradle build will fail if all files don't have copyright header

Signed-off-by: tobias.pobocik <tobias.pobocik@pantheon.tech>