### PR TITLE
📝 modified relative path to the README file

### DIFF
--- a/intelij-plugin/docs/README.md
+++ b/intelij-plugin/docs/README.md
@@ -1,6 +1,6 @@
 # How to successfully enable Highlighter
 
-* Step 1 : generate lexer and parser according to tutorial [here](rfc-parser/docs/README.md)
+* Step 1 : generate lexer and parser according to tutorial [here](/../../blob/master/rfc-parser/docs/README.md)
 * Step 2 : navigate into intelij-plugin-1-1/src/main/java/tech/pantheon/yanginator/plugin/highlighter
 and right-click YangHighlighter.bnf and select Generate Parser Code
 * Step 3 : right-click the bnf again and select Generate JFlex Lexer, the path for generated lexer should be gen/tech/pantheon/yanginator/plugin/highlighter


### PR DESCRIPTION
The previous relative path fails to navigate to the /rfc-parser/docs/README.md (causes 404 error - page not found). This path should do the job