### PR TITLE
changed externalName to be unique

### DIFF
--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/highlighter/YangSyntaxHighlighter.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/highlighter/YangSyntaxHighlighter.java
@@ -41,7 +41,7 @@ public class YangSyntaxHighlighter extends SyntaxHighlighterBase {
     public static final TextAttributesKey OP_SIGN = createTextAttributesKey("YANG_OP_SIGN", DefaultLanguageHighlighterColors.OPERATION_SIGN);
     public static final TextAttributesKey SEMICOLON = createTextAttributesKey("YANG_SEMICOLON", DefaultLanguageHighlighterColors.SEMICOLON);
     public static final TextAttributesKey UNKNOWN = createTextAttributesKey("YANG_UNKNOWN", DefaultLanguageHighlighterColors.CONSTANT);
-    public static final TextAttributesKey IDENTIFIER = createTextAttributesKey("YANG_UNKNOWN", DefaultLanguageHighlighterColors.IDENTIFIER);
+    public static final TextAttributesKey IDENTIFIER = createTextAttributesKey("YANG_IDENTIFIER", DefaultLanguageHighlighterColors.IDENTIFIER);
 
     @NotNull
     @Override


### PR DESCRIPTION
# Description

The externalName (i.e. the unique identifier of a key) of the TextAttributesKey is chaged to be unique. Before it shared this externalName with other field, making it not unique, which resolved in an IllegalStateException. The exception is no longer thrown here

Fixes # 125

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)