### PR TITLE
Issue # 127 - Fixes NullPointerException in the YangBreadcrumbsProvider

### DIFF
--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/breadcrumbs/YangBreadcrumbsProvider.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/breadcrumbs/YangBreadcrumbsProvider.java
@@ -22,8 +22,6 @@ import tech.pantheon.yanginator.plugin.psi.YangLeafStmt;
 import tech.pantheon.yanginator.plugin.psi.YangListStmt;
 import tech.pantheon.yanginator.plugin.psi.impl.YangIdentifierArgImpl;
 
-import java.util.Objects;
-
 public class YangBreadcrumbsProvider implements BreadcrumbsProvider {
 
     @Override
@@ -42,10 +40,7 @@ public class YangBreadcrumbsProvider implements BreadcrumbsProvider {
     @NotNull
     @Override
     public String getElementInfo(@NotNull PsiElement psiElement) {
-        try {
-            return Objects.requireNonNull(PsiTreeUtil.findChildOfType(psiElement, YangIdentifierArgImpl.class)).getText();
-        }catch(NullPointerException e) {
-            return "";
-        }
+        YangIdentifierArgImpl breadcrumbsContent = PsiTreeUtil.findChildOfType(psiElement, YangIdentifierArgImpl.class);
+        return breadcrumbsContent != null ? breadcrumbsContent.getText() : "";
     }
 }

--- a/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/breadcrumbs/YangBreadcrumbsProvider.java
+++ b/intelij-plugin/src/main/java/tech/pantheon/yanginator/plugin/breadcrumbs/YangBreadcrumbsProvider.java
@@ -42,6 +42,10 @@ public class YangBreadcrumbsProvider implements BreadcrumbsProvider {
     @NotNull
     @Override
     public String getElementInfo(@NotNull PsiElement psiElement) {
-        return Objects.requireNonNull(PsiTreeUtil.findChildOfType(psiElement, YangIdentifierArgImpl.class)).getText();
+        try {
+            return Objects.requireNonNull(PsiTreeUtil.findChildOfType(psiElement, YangIdentifierArgImpl.class)).getText();
+        }catch(NullPointerException e) {
+            return "";
+        }
     }
 }


### PR DESCRIPTION
# Description

The content of the breadcrumbs is the identifier that goes after the keyword. 
In the Example 1 below, the breadcrumbs would look like this:    `parms > mod-con-3 > mod-instance-table > mod-instance-id`

Example 1:
``` YANG
grouping parms {
    description
    "parms";
    container mod-con-3 {
        list mod-instance-table {
            key "mod-instance-id";
            description
            "Some list";
            leaf mod-instance-id {
                type uint32;
                description
                "Id for an instance in the list";
            }
        }
    }
}
```

However, if the identifier wasn't given yet (Example 2 -> keyword 'container' is missing its identifier), an exception was thrown

``` YANG
grouping parms {
    description
    "parms";
    container 
}
```

After this fix, the NullPointerException is no longer being thrown and the breadcrumbs field for the identifier stays empty.
For the Example 2 the breadcrumbs would look like this:    `parms > `

Fixes # 127

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

Signed-off-by: simon.ukus <simon.ukus@pantheon.tech>